### PR TITLE
create new map generation type

### DIFF
--- a/includes/elements/Crispy.hpp
+++ b/includes/elements/Crispy.hpp
@@ -23,6 +23,8 @@ public:
 	bool	postUpdate();
 	bool	draw(Gui &gui);
 
+	static Crispy *	generateCrispy(SceneGame &game, uint32_t genWallPercent);
+
 	// Exceptions
 	class CrispyException : public std::runtime_error {
 	public:

--- a/includes/elements/EnemyBasic.hpp
+++ b/includes/elements/EnemyBasic.hpp
@@ -30,7 +30,4 @@ public:
 
 	// Operators
 	EnemyBasic &operator=(EnemyBasic const &rhs);
-
-	// Methods
-	static EnemyBasic *	generateEnemy(SceneGame &game, float rate);
 };

--- a/includes/elements/EnemyFollow.hpp
+++ b/includes/elements/EnemyFollow.hpp
@@ -39,7 +39,4 @@ public:
 
 	// Operators
 	EnemyFollow &operator=(EnemyFollow const &rhs);
-
-	// Methods
-	static EnemyFollow *	generateEnemy(SceneGame &game, float rate);
 };

--- a/includes/elements/EnemyWithEye.hpp
+++ b/includes/elements/EnemyWithEye.hpp
@@ -31,7 +31,4 @@ public:
 
 	// Operators
 	EnemyWithEye &operator=(EnemyWithEye const &rhs);
-
-	// Methods
-	static EnemyWithEye *	generateEnemy(SceneGame &game, float rate);
 };

--- a/srcs/elements/Crispy.cpp
+++ b/srcs/elements/Crispy.cpp
@@ -62,6 +62,17 @@ bool	Crispy::draw(Gui &gui) {
 	return true;
 }
 
+Crispy * Crispy::generateCrispy(SceneGame &game, uint32_t genWallPercent) {
+	if (genWallPercent <= 0)
+		return nullptr;
+	if (genWallPercent >= 100)
+		return new Crispy(game);
+
+	if (rand() % 100 > genWallPercent)
+		return nullptr;
+	return new Crispy(game);
+}
+
 // -- Exceptions errors --------------------------------------------------------
 
 Crispy::CrispyException::CrispyException()

--- a/srcs/elements/Crispy.cpp
+++ b/srcs/elements/Crispy.cpp
@@ -68,7 +68,7 @@ Crispy * Crispy::generateCrispy(SceneGame &game, uint32_t genWallPercent) {
 	if (genWallPercent >= 100)
 		return new Crispy(game);
 
-	if (rand() % 100 > genWallPercent)
+	if (static_cast<uint32_t>(rand() % 100) > genWallPercent)
 		return nullptr;
 	return new Crispy(game);
 }

--- a/srcs/elements/EnemyBasic.cpp
+++ b/srcs/elements/EnemyBasic.cpp
@@ -68,24 +68,3 @@ bool	EnemyBasic::_draw(Gui &gui) {
 	gui.drawCube(Block::IA, getPos());
 	return true;
 }
-
-/**
- * @brief Static class to generate enemies
- *
- * @param game
- * @param rate Probability to generate an enemy is between 0 and 1.
- * @return EnemyBasic*
- */
-EnemyBasic*	EnemyBasic::generateEnemy(SceneGame &game, float rate) {
-	if (rate <= 0.0f)
-		return nullptr;
-	if (rate >= 1.0f)
-		return new EnemyBasic(game);
-
-	int		percentRate = rand() % 100;
-	// logInfo("percentRate: " << percentRate);
-	// logInfo("rate: " << static_cast<int>(rate * 100));
-	if (percentRate > static_cast<int>(rate * 100))
-		return nullptr;
-	return new EnemyBasic(game);
-}

--- a/srcs/elements/EnemyFollow.cpp
+++ b/srcs/elements/EnemyFollow.cpp
@@ -92,24 +92,3 @@ bool	EnemyFollow::_draw(Gui &gui) {
 	gui.drawCube(Block::IA, getPos());
 	return true;
 }
-
-/**
- * @brief Static class to generate enemies
- *
- * @param game
- * @param rate Probability to generate an enemy is between 0 and 1.
- * @return EnemyFollow*
- */
-EnemyFollow*	EnemyFollow::generateEnemy(SceneGame &game, float rate) {
-	if (rate <= 0.0f)
-		return nullptr;
-	if (rate >= 1.0f)
-		return new EnemyFollow(game);
-
-	int		percentRate = rand() % 100;
-	// logInfo("percentRate: " << percentRate);
-	// logInfo("rate: " << static_cast<int>(rate * 100));
-	if (percentRate > static_cast<int>(rate * 100))
-		return nullptr;
-	return new EnemyFollow(game);
-}

--- a/srcs/elements/EnemyWithEye.cpp
+++ b/srcs/elements/EnemyWithEye.cpp
@@ -76,24 +76,3 @@ bool	EnemyWithEye::_draw(Gui &gui) {
 	gui.drawCube(Block::IA, getPos());
 	return true;
 }
-
-/**
- * @brief Static class to generate enemies
- *
- * @param game
- * @param rate Probability to generate an enemy is between 0 and 1.
- * @return EnemyWithEye*
- */
-EnemyWithEye*	EnemyWithEye::generateEnemy(SceneGame &game, float rate) {
-	if (rate <= 0.0f)
-		return nullptr;
-	if (rate >= 1.0f)
-		return new EnemyWithEye(game);
-
-	int		percentRate = rand() % 100;
-	// logInfo("percentRate: " << percentRate);
-	// logInfo("rate: " << static_cast<int>(rate * 100));
-	if (percentRate > static_cast<int>(rate * 100))
-		return nullptr;
-	return new EnemyWithEye(game);
-}


### PR DESCRIPTION
close #79 

j'ai un peu modifié la generation de la map:
- on doit definir quel enemy vont apparaitre et ou ils vont apparaitre
- les espace "empty" serons remplacer par des crispy wall (avec une certaine probabilité: `wallGenPercent`)

ca va avec la PR dans les [assets](https://github.com/tnicolas42/bomberman-assets/pull/1)