### PR TITLE
#99 player initialisation level

### DIFF
--- a/includes/scenes/SceneGame.hpp
+++ b/includes/scenes/SceneGame.hpp
@@ -93,6 +93,7 @@ public:
 	std::vector< std::vector< std::vector<AEntity *> > > board;
 	std::vector< std::vector< std::vector<AEntity *> > > boardFly;
 	Player						*player;
+	Player						*playerSaved;
 	std::vector<AEnemy *>		enemies;
 	struct BonusValues {
 		int64_t	chance;

--- a/includes/scenes/SceneGame.hpp
+++ b/includes/scenes/SceneGame.hpp
@@ -54,6 +54,7 @@ private:
 	static std::map<std::string, Entity> _entitiesCall;
 
 	std::vector<SettingsJson *>	_mapsList;
+	Player						*_playerSaved;
 
 	// Methods
 	bool	_loadLevel(int32_t levelId);
@@ -93,7 +94,6 @@ public:
 	std::vector< std::vector< std::vector<AEntity *> > > board;
 	std::vector< std::vector< std::vector<AEntity *> > > boardFly;
 	Player						*player;
-	Player						*playerSaved;
 	std::vector<AEnemy *>		enemies;
 	struct BonusValues {
 		int64_t	chance;

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -82,8 +82,10 @@ SceneGame::~SceneGame() {
 	}
 	boardFly.clear();
 	if (player != nullptr) {
-		// TODO(ebaudet): save player if state is not GameOver.
 		delete player;
+	}
+	if (playerSaved != nullptr) {
+		delete playerSaved;
 	}
 	std::vector<AEnemy *>::iterator it = enemies.begin();
 	AEnemy *enemy;
@@ -159,6 +161,8 @@ bool			SceneGame::init() {
 		i++;
 	}
 
+	playerSaved = new Player(*this);
+
 	_initGameInfos();
 
 	return true;
@@ -230,11 +234,13 @@ bool	SceneGame::update() {
 		score.addBonusTime(levelTime, time);
 		score.addBonusEnemies(levelEnemies, enemies.size(), levelCrispies, crispiesLast);
 		SceneManager::loadScene(SceneNames::VICTORY);
+		*playerSaved = *player;
 		return true;
 	}
 	else if (state == GameState::GAME_OVER) {
 		// clear game infos.
 		player->resetParams();
+		*playerSaved = *player;
 		SceneManager::loadScene(SceneNames::GAME_OVER);
 		return true;
 	}
@@ -397,6 +403,9 @@ bool SceneGame::loadLevel(int32_t levelId) {
 		size.y / 1.9
 	));
 
+	playerSaved->setPosition(player->getPos());
+	// get saved values
+	*player = *playerSaved;
 	player->init();
 	time = 0;
 	levelEnemies = enemies.size();

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -84,8 +84,8 @@ SceneGame::~SceneGame() {
 	if (player != nullptr) {
 		delete player;
 	}
-	if (playerSaved != nullptr) {
-		delete playerSaved;
+	if (_playerSaved != nullptr) {
+		delete _playerSaved;
 	}
 	std::vector<AEnemy *>::iterator it = enemies.begin();
 	AEnemy *enemy;
@@ -161,7 +161,7 @@ bool			SceneGame::init() {
 		i++;
 	}
 
-	playerSaved = new Player(*this);
+	_playerSaved = new Player(*this);
 
 	_initGameInfos();
 
@@ -234,13 +234,13 @@ bool	SceneGame::update() {
 		score.addBonusTime(levelTime, time);
 		score.addBonusEnemies(levelEnemies, enemies.size(), levelCrispies, crispiesLast);
 		SceneManager::loadScene(SceneNames::VICTORY);
-		*playerSaved = *player;
+		*_playerSaved = *player;
 		return true;
 	}
 	else if (state == GameState::GAME_OVER) {
 		// clear game infos.
 		player->resetParams();
-		*playerSaved = *player;
+		*_playerSaved = *player;
 		SceneManager::loadScene(SceneNames::GAME_OVER);
 		return true;
 	}
@@ -403,9 +403,9 @@ bool SceneGame::loadLevel(int32_t levelId) {
 		size.y / 1.9
 	));
 
-	playerSaved->setPosition(player->getPos());
+	_playerSaved->setPosition(player->getPos());
 	// get saved values
-	*player = *playerSaved;
+	*player = *_playerSaved;
 	player->init();
 	time = 0;
 	levelEnemies = enemies.size();


### PR DESCRIPTION
Au début d'un niveau, les values du player doivent être réinitialisée avec les valeurs du dernier niveau fini.

Si gameOver : reset des valueurs.
Si quit en cours, remettre les valeurs de début du niveau.
