### PR TITLE
Feature/settings 2

### DIFF
--- a/includes/bomberman.hpp
+++ b/includes/bomberman.hpp
@@ -15,6 +15,8 @@
 #define CHEATCODE_HIST_FILE		CONFIG_DIR"history.cheatcode"
 #define SAVE_DIR				"saves/"
 
+#define RESTART_TO_UPDATE_RESOLUTION	true  // restart game to reset resolution
+
 #include <chrono>
 #include "SettingsJson.hpp"
 #include "Logging.hpp"

--- a/includes/gui/Gui.hpp
+++ b/includes/gui/Gui.hpp
@@ -27,6 +27,7 @@
 struct GameInfo {
 	std::string	title;
 	glm::ivec2	windowSize;
+	glm::ivec2	maxWindowSize;
 	bool		quit;
 
 	GameInfo();

--- a/includes/gui/Gui.hpp
+++ b/includes/gui/Gui.hpp
@@ -28,6 +28,8 @@ struct GameInfo {
 	std::string	title;
 	glm::ivec2	windowSize;
 	glm::ivec2	maxWindowSize;
+	glm::ivec2	savedWindowSize;
+	bool		isSavedFullscreen;
 	bool		quit;
 
 	GameInfo();

--- a/includes/scenes/SceneSettings.hpp
+++ b/includes/scenes/SceneSettings.hpp
@@ -26,6 +26,8 @@ public:
 	static SceneSettings::res	resolutions[SceneSettings::nb_resolution];
 	static const std::string	audio_name[3];
 
+	bool					startFitToScreen;
+
 	virtual ~SceneSettings();
 	explicit SceneSettings(Gui * gui, float const &dtTime);
 	SceneSettings(SceneSettings const &src);
@@ -34,6 +36,8 @@ public:
 
 	virtual bool				init();
 	virtual bool				update();
+
+	glm::ivec2					getCurResolution() const;
 
 private:
 	SceneSettings();
@@ -77,7 +81,6 @@ private:
 	/* temporary settings */
 	bool						_fullscreen;
 	float						_audio_volume[3];
-	bool						_start_fit_to_screen;
 
 	/* UI listeners */
 	bool						_return;

--- a/includes/scenes/SceneSettings.hpp
+++ b/includes/scenes/SceneSettings.hpp
@@ -45,6 +45,7 @@ private:
 	void						_updateMouseSensitivity();
 	void						_updateFullscreen();
 	void						_updateResolution(bool go_right);
+	void						_resetKeys();
 	void						_returnQuit();
 	void						_cancelQuit();
 
@@ -68,6 +69,7 @@ private:
 	SettingsType::Enum			_current_pane;
 	std::list<ABaseUI*>			_panes[SettingsType::nb_types];
 	ButtonUI					*_key_buttons[Inputs::nb_input];
+	ButtonUI					*_paneSelection[SettingsType::nb_types];
 	ButtonUI					*_fullscreen_button;
 	TextUI						*_resolution_text;
 
@@ -77,6 +79,7 @@ private:
 
 	/* UI listeners */
 	bool						_return;
+	bool						_reset;
 	bool						_next_resolution;
 	bool						_prev_resolution;
 	bool						_update_fullscreen;

--- a/includes/scenes/SceneSettings.hpp
+++ b/includes/scenes/SceneSettings.hpp
@@ -62,7 +62,6 @@ private:
 	float						_text_scale = 1.5f;
 	int							_input_configuring;
 	SceneSettings::res			_current_resolution;
-	SceneSettings::res			_custom_res;
 	int							_select_res;
 
 	/* UI object */

--- a/includes/scenes/SceneSettings.hpp
+++ b/includes/scenes/SceneSettings.hpp
@@ -70,12 +70,14 @@ private:
 	ButtonUI					*_key_buttons[Inputs::nb_input];
 	ButtonUI					*_paneSelection[SettingsType::nb_types];
 	ButtonUI					*_fullscreen_button;
+	ButtonUI					*_fit_to_screen_button;
 	TextUI						*_resolution_text;
 	TextUI						*_reloadWinText;
 
 	/* temporary settings */
 	bool						_fullscreen;
 	float						_audio_volume[3];
+	bool						_start_fit_to_screen;
 
 	/* UI listeners */
 	bool						_return;
@@ -83,6 +85,7 @@ private:
 	bool						_next_resolution;
 	bool						_prev_resolution;
 	bool						_update_fullscreen;
+	bool						_update_fit_to_screen;
 	bool						_save_audio[3];
 	float						_update_audio[3];
 	bool						_save_mouse_sens;

--- a/includes/scenes/SceneSettings.hpp
+++ b/includes/scenes/SceneSettings.hpp
@@ -22,7 +22,7 @@ public:
 		int				height;
 	};
 
-	static const int			nb_resolution = 6;
+	static const int			nb_resolution = 7;
 	static SceneSettings::res	resolutions[SceneSettings::nb_resolution];
 	static const std::string	audio_name[3];
 
@@ -72,6 +72,7 @@ private:
 	ButtonUI					*_paneSelection[SettingsType::nb_types];
 	ButtonUI					*_fullscreen_button;
 	TextUI						*_resolution_text;
+	TextUI						*_reloadWinText;
 
 	/* temporary settings */
 	bool						_fullscreen;

--- a/includes/utils/opengl/Inputs.hpp
+++ b/includes/utils/opengl/Inputs.hpp
@@ -1,5 +1,5 @@
 #ifndef INPUTS_HPP
-# define INPUTS_HPP
+#define INPUTS_HPP
 
 #include <SDL2/SDL.h>
 #include <map>
@@ -11,6 +11,19 @@
 // equivalent of NULL for scancode & keycode
 #define NO_SCANCODE	SDL_SCANCODE_F24
 #define NO_KEYCODE	SDLK_F24
+
+// default input value
+#define DEFAULT_UP			SDL_SCANCODE_UP
+#define DEFAULT_DOWN		SDL_SCANCODE_DOWN
+#define DEFAULT_LEFT		SDL_SCANCODE_LEFT
+#define DEFAULT_RIGHT		SDL_SCANCODE_RIGHT
+#define DEFAULT_ACTION		SDL_SCANCODE_SPACE
+#define DEFAULT_ACTION_2	SDL_SCANCODE_B
+#define DEFAULT_CONFIRM		SDL_SCANCODE_RETURN
+#define DEFAULT_CANCEL		SDL_SCANCODE_ESCAPE
+#define DEFAULT_MENU		SDL_SCANCODE_TAB
+#define DEFAULT_HELP		SDL_SCANCODE_F1
+#define DEFAULT_CHEATCODE	SDL_SCANCODE_SLASH
 
 /**
  * @brief this is the list of all user-defined inputs
@@ -45,6 +58,7 @@ public:
 	static const int						nb_input = InputType::NB_INPUTS;
 	static const std::string				input_type_name[Inputs::nb_input];
 	static const std::string				configFile;
+	static const SDL_Scancode				default_keys[InputType::NB_INPUTS];
 
 	~Inputs();
 
@@ -70,6 +84,7 @@ public:
 	static bool								getRightClickDown();
 	static bool								getLeftClickDown();
 	static void								update();
+	static void								resetKeys();
 	static bool								isConfiguring();
 	static void								setTextInputMode(bool enable);
 	static SDL_Keycode						getTextInputKeycode();
@@ -101,6 +116,7 @@ private:
 	bool									_getRightClickDown() const;
 	bool									_getLeftClickDown() const;
 	void									_update();
+	void									_resetKeys();
 	bool									_isConfiguring();
 	void									_setTextInputMode(bool enable);
 	SDL_Keycode								_getTextInputKeycode() const;

--- a/includes/utils/opengl/UI/ScrollbarUI.hpp
+++ b/includes/utils/opengl/UI/ScrollbarUI.hpp
@@ -41,6 +41,7 @@ class ScrollbarUI : public ABaseMasterUI {
 
 		// vertical
 		bool		_vertScroll;
+		bool		_vertScrollHide;  // hide because his size is 100%
 		bool		_vertScrollInverted;
 		float		_vertScrollbarPos;
 		float		_vertScrollBarDrawSize;
@@ -48,6 +49,7 @@ class ScrollbarUI : public ABaseMasterUI {
 
 		// horizontal
 		bool		_horizScroll;
+		bool		_horizScrollHide;  // hide because his size is 100%
 		bool		_horizScrollInverted;
 		float		_horizScrollbarPos;
 		float		_horizScrollBarDrawSize;

--- a/srcs/bomberman.cpp
+++ b/srcs/bomberman.cpp
@@ -173,6 +173,7 @@ bool	initSettings(std::string const & filename) {
 	/* Graphics */
 	s.add<SettingsJson>("graphics");
 	s.j("graphics").add<bool>("fullscreen", false).setDescription("Display the game on fullscreen or not.");
+	s.j("graphics").add<bool>("fitToScreen", false).setDescription("The resolution fit to the screen size");
 	s.j("graphics").add<int64_t>("width", 1200).setMin(800).setMax(2560).setDescription("The resolution's width.");
 	s.j("graphics").add<int64_t>("height", 800).setMin(600).setMax(1440).setDescription("The resolution's height.");
 

--- a/srcs/gui/Gui.cpp
+++ b/srcs/gui/Gui.cpp
@@ -92,9 +92,6 @@ void Gui::postUpdate(float const dtTime) {
 				if (SceneManager::getSceneName() != SceneNames::EXIT) {
 					SceneManager::loadScene(SceneNames::EXIT);
 				}
-				else if (Inputs::shouldQuit()) {
-					SceneManager::quit();
-				}
 			#else
 				SceneManager::quit();
 			#endif

--- a/srcs/gui/Gui.cpp
+++ b/srcs/gui/Gui.cpp
@@ -309,6 +309,8 @@ bool	Gui::_protect_resolution() {
 		logWarn("Screen too small.");
 		return false;
 	}
+	gameInfo.maxWindowSize.x = dm.w;
+	gameInfo.maxWindowSize.y = dm.h;
 	logDebug("width max: " << dm.w << " ; height max: " << dm.h);
 	if (dm.w < width) {
 		width = dm.w;

--- a/srcs/gui/Gui.cpp
+++ b/srcs/gui/Gui.cpp
@@ -92,6 +92,9 @@ void Gui::postUpdate(float const dtTime) {
 				if (SceneManager::getSceneName() != SceneNames::EXIT) {
 					SceneManager::loadScene(SceneNames::EXIT);
 				}
+				else if (Inputs::shouldQuit()) {
+					SceneManager::quit();
+				}
 			#else
 				SceneManager::quit();
 			#endif

--- a/srcs/gui/Gui.cpp
+++ b/srcs/gui/Gui.cpp
@@ -319,7 +319,11 @@ bool	Gui::_protect_resolution() {
 	}
 	gameInfo.maxWindowSize.x = dm.w;
 	gameInfo.maxWindowSize.y = dm.h;
-	logDebug("width max: " << dm.w << " ; height max: " << dm.h);
+	if (s.j("graphics").b("fitToScreen")) {
+		s.j("graphics").i("width") = gameInfo.maxWindowSize.x;
+		s.j("graphics").i("height") = gameInfo.maxWindowSize.y;
+		resolution_corrected = true;
+	}
 	if (dm.w < width) {
 		width = dm.w;
 		resolution_corrected = true;
@@ -338,6 +342,7 @@ bool	Gui::_protect_resolution() {
 		height = width * 9.0 / 16.0;
 		resolution_corrected = true;
 	}
+	logDebug("Screen resolution: " << width << "x" << height);
 	if (resolution_corrected) {
 		gameInfo.windowSize.x = width;
 		gameInfo.windowSize.y = height;

--- a/srcs/gui/Gui.cpp
+++ b/srcs/gui/Gui.cpp
@@ -38,8 +38,13 @@ Gui::~Gui() {
 
 	// properly quit sdl
 	SDL_GL_DeleteContext(_context);
-	SDL_DestroyWindow(_win);
-    SDL_Quit();
+	try {
+		SDL_DestroyWindow(_win);
+		SDL_Quit();
+	}
+	catch (std::exception & e) {
+		logWarn("failed to exit proprely SDL window");
+	}
 }
 
 Gui::Gui(Gui const &src)

--- a/srcs/gui/Gui.cpp
+++ b/srcs/gui/Gui.cpp
@@ -135,6 +135,9 @@ bool	Gui::init() {
 
 	/* init UI interface */
 	try {
+		gameInfo.savedWindowSize.x = s.j("graphics").i("width");
+		gameInfo.savedWindowSize.y = s.j("graphics").i("height");
+		gameInfo.isSavedFullscreen = s.j("graphics").b("fullscreen");
 		ABaseUI::init(gameInfo.windowSize, s.j("fonts").j("base").s("file"), s.j("fonts").j("base").u("size"));
 		ABaseUI::loadFont("title", s.j("fonts").j("base").s("file"), s.j("fonts").j("base").u("size") * 2);
 		ABaseUI::loadFont("cheatcode", s.j("fonts").j("cheatcode").s("file"), s.j("fonts").j("cheatcode").u("size") * 3);

--- a/srcs/scenes/SceneLevelSelection.cpp
+++ b/srcs/scenes/SceneLevelSelection.cpp
@@ -151,7 +151,7 @@ bool	SceneLevelSelection::update() {
 			return true;
 		}
 	}
-	if (_states.menu) {
+	if (_states.menu || Inputs::getKeyUp(InputType::CANCEL)) {
 		_states.menu = false;
 		SceneManager::loadScene(SceneNames::MAIN_MENU);
 	}

--- a/srcs/scenes/SceneLoadGame.cpp
+++ b/srcs/scenes/SceneLoadGame.cpp
@@ -250,7 +250,7 @@ bool	SceneLoadGame::update() {
 		scGame.loadLevel(scGame.level);  // reload the current level
 		SceneManager::loadScene(_lastSceneName);
 	}
-	else if (_states.menu) {
+	else if (_states.menu || Inputs::getKeyUp(InputType::CANCEL)) {
 		_states.menu = false;
 		SceneManager::loadScene(SceneNames::MAIN_MENU);
 	}

--- a/srcs/scenes/SceneManager.cpp
+++ b/srcs/scenes/SceneManager.cpp
@@ -33,6 +33,11 @@ SceneManager::SceneManager(SceneManager const & src) {
 }
 
 SceneManager::~SceneManager() {
+	SceneSettings & scSettings = *reinterpret_cast<SceneSettings*>(getScene(SceneNames::SETTINGS));
+	if (scSettings.startFitToScreen && !s.j("graphics").b("fitToScreen")) {
+		_gui->gameInfo.savedWindowSize.x = scSettings.getCurResolution().x;
+		_gui->gameInfo.savedWindowSize.y = scSettings.getCurResolution().y;
+	}
 	s.j("graphics").i("width") = _gui->gameInfo.savedWindowSize.x;
 	s.j("graphics").i("height") = _gui->gameInfo.savedWindowSize.y;
 	s.j("graphics").b("fullscreen") = _gui->gameInfo.isSavedFullscreen;

--- a/srcs/scenes/SceneManager.cpp
+++ b/srcs/scenes/SceneManager.cpp
@@ -33,6 +33,10 @@ SceneManager::SceneManager(SceneManager const & src) {
 }
 
 SceneManager::~SceneManager() {
+	s.j("graphics").i("width") = _gui->gameInfo.savedWindowSize.x;
+	s.j("graphics").i("height") = _gui->gameInfo.savedWindowSize.y;
+	s.j("graphics").b("fullscreen") = _gui->gameInfo.isSavedFullscreen;
+	saveSettings(SETTINGS_FILE);
 	delete _gui;
 	for (auto it = _sceneMap.begin(); it != _sceneMap.end(); it++) {
 		delete it->second;

--- a/srcs/scenes/SceneSettings.cpp
+++ b/srcs/scenes/SceneSettings.cpp
@@ -36,10 +36,6 @@ SceneSettings::SceneSettings(Gui *gui, float const &dtTime) : ASceneMenu(gui, dt
 		width,
 		height
 	};
-	_custom_res = {
-		_gui->gameInfo.maxWindowSize.x,
-		_gui->gameInfo.maxWindowSize.y,
-	};
 	_select_res = -1;  // setted in init function
 	_text_scale = static_cast<float>(width) * 0.001;
 }
@@ -74,7 +70,6 @@ SceneSettings			&SceneSettings::operator=(SceneSettings const &rhs) {
 	_update_mouse_sens = rhs._update_mouse_sens;
 	_fullscreen_button = rhs._fullscreen_button;
 	_text_scale = rhs._text_scale;
-	_custom_res = rhs._custom_res;
 	_select_res = rhs._select_res;
 	return *this;
 }

--- a/srcs/scenes/SceneSettings.cpp
+++ b/srcs/scenes/SceneSettings.cpp
@@ -40,7 +40,7 @@ SceneSettings::SceneSettings(Gui *gui, float const &dtTime) : ASceneMenu(gui, dt
 		_gui->gameInfo.maxWindowSize.x,
 		_gui->gameInfo.maxWindowSize.y,
 	};
-	_select_res = SceneSettings::nb_resolution;
+	_select_res = -1;  // setted in init function
 	_text_scale = static_cast<float>(width) * 0.001;
 }
 SceneSettings::SceneSettings(SceneSettings const &src) : ASceneMenu(src) {
@@ -104,6 +104,26 @@ bool					SceneSettings::init() {
 	glm::vec2 tmp_size;
 	float menu_width = win_size.x * 0.8;
 	float menu_height = win_size.y * 0.9;
+
+	_select_res = -1;
+	for (int i = 0; i < SceneSettings::nb_resolution; i++) {
+		if (resolutions[i].width == s.j("graphics").i("width")
+		&& resolutions[i].height == s.j("graphics").i("height"))
+		{
+			_select_res = i;
+			break;
+		}
+	}
+	if (_select_res == -1) {
+		logErr("Invalid resolution " << s.j("graphics").i("width") << "x" << s.j("graphics").i("height"));
+		s.j("graphics").i("width") = resolutions[0].width;
+		s.j("graphics").i("height") = resolutions[0].height;
+		_gui->gameInfo.savedWindowSize.x = s.j("graphics").i("width");
+		_gui->gameInfo.savedWindowSize.y = s.j("graphics").i("height");
+		logInfo("save new resolution " << s.j("graphics").i("width") << "x" << s.j("graphics").i("height"));
+		saveSettings(SETTINGS_FILE);
+		return false;
+	}
 
 	for (auto i = 0; i < SceneSettings::nb_resolution; i++) {
 		if (SceneSettings::resolutions[i].width == _custom_res.width \

--- a/srcs/scenes/SceneSettings.cpp
+++ b/srcs/scenes/SceneSettings.cpp
@@ -177,13 +177,17 @@ void					SceneSettings::_init_graphics_pane(glm::vec2 tmp_pos, float menu_width,
 	tmp_size.x = menu_width / 3;
 	tmp_pos.x = (win_size.x / 2) - (menu_width / 2);
 	tmp_pos.y -= menu_height * 0.2;
-	ptr = &addText(tmp_pos, tmp_size, "Fullscreen :").setTextAlign(TextAlign::RIGHT) \
-		.setTextScale(_text_scale).setEnabled(true);
+	ptr = &addText(tmp_pos, tmp_size, "Fullscreen :")
+		.setTextAlign(TextAlign::RIGHT)
+		.setTextScale(_text_scale)
+		.setEnabled(true);
 	_panes[SettingsType::GRAPHICS].push_front(ptr);
 	tmp_size.x = menu_width / 10;
 	tmp_pos.x += menu_width / 2 + menu_width / 6 - tmp_size.x / 2;
 	_fullscreen_button = &addButton(tmp_pos, tmp_size, "OFF");
-	ptr = &_fullscreen_button->addButtonLeftListener(&_update_fullscreen).setTextScale(_text_scale) \
+	ptr = &_fullscreen_button->addButtonLeftListener(&_update_fullscreen)
+		.setKeyLeftClickScancode(SDL_SCANCODE_F)
+		.setTextScale(_text_scale)
 		.setTextAlign(TextAlign::CENTER);
 	_updateFullscreenButton();
 	_panes[SettingsType::GRAPHICS].push_front(ptr);
@@ -191,23 +195,32 @@ void					SceneSettings::_init_graphics_pane(glm::vec2 tmp_pos, float menu_width,
 	tmp_size.x = menu_width / 3;
 	tmp_pos.x = (win_size.x / 2) - (menu_width / 2);
 	tmp_pos.y -= menu_height * 0.3;
-	ptr = &addText(tmp_pos, tmp_size, "Resolution :").setTextAlign(TextAlign::RIGHT) \
-		.setTextScale(_text_scale).setEnabled(true);
+	ptr = &addText(tmp_pos, tmp_size, "Resolution :")
+		.setTextAlign(TextAlign::RIGHT)
+		.setTextScale(_text_scale)
+		.setEnabled(true);
 	_panes[SettingsType::GRAPHICS].push_front(ptr);
 	tmp_pos.x += (menu_width / 2);
 	_resolution_text = &addText(tmp_pos, tmp_size, "800x600");
-	ptr = &_resolution_text->setTextAlign(TextAlign::CENTER) \
-		.setTextScale(_text_scale).setEnabled(true);
+	ptr = &_resolution_text->setTextAlign(TextAlign::CENTER)
+		.setTextScale(_text_scale)
+		.setEnabled(true);
 	_updateResolutionText();
 	_panes[SettingsType::GRAPHICS].push_front(ptr);
 	tmp_size.x = menu_width / 10;
 	tmp_pos.x -= tmp_size.x;
-	ptr = &addButton(tmp_pos, tmp_size, "<").addButtonLeftListener(&_prev_resolution) \
-		.setTextScale(_text_scale).setEnabled(true);
+	ptr = &addButton(tmp_pos, tmp_size, "<")
+		.setKeyLeftClickScancode(SDL_SCANCODE_LEFT)
+		.addButtonLeftListener(&_prev_resolution)
+		.setTextScale(_text_scale)
+		.setEnabled(true);
 	_panes[SettingsType::GRAPHICS].push_front(ptr);
 	tmp_pos.x += menu_width / 3 + tmp_size.x;
-	ptr = &addButton(tmp_pos, tmp_size, ">").addButtonLeftListener(&_next_resolution) \
-		.setTextScale(_text_scale).setEnabled(true);
+	ptr = &addButton(tmp_pos, tmp_size, ">")
+		.setKeyLeftClickScancode(SDL_SCANCODE_RIGHT)
+		.addButtonLeftListener(&_next_resolution)
+		.setTextScale(_text_scale)
+		.setEnabled(true);
 	_panes[SettingsType::GRAPHICS].push_front(ptr);
 }
 

--- a/srcs/scenes/SceneSettings.cpp
+++ b/srcs/scenes/SceneSettings.cpp
@@ -125,15 +125,6 @@ bool					SceneSettings::init() {
 		return false;
 	}
 
-	for (auto i = 0; i < SceneSettings::nb_resolution; i++) {
-		if (SceneSettings::resolutions[i].width == _custom_res.width \
-			&& SceneSettings::resolutions[i].height == _custom_res.height)
-		{
-			_custom_res = { 0, 0 };
-			_select_res = i;
-			break;
-		}
-	}
 	try {
 		tmp_size.y = menu_height * 0.1;
 		tmp_size.x = tmp_size.y;
@@ -571,8 +562,8 @@ void					SceneSettings::_updateResolution(bool go_right) {
 	if (_select_res < 0) {
 		_select_res = 0;
 	}
-	else if (_select_res > SceneSettings::nb_resolution) {
-		_select_res = SceneSettings::nb_resolution;
+	else if (_select_res >= SceneSettings::nb_resolution) {
+		_select_res = SceneSettings::nb_resolution - 1;
 	}
 	while (SceneSettings::resolutions[_select_res].width > _gui->gameInfo.maxWindowSize.x
 	|| SceneSettings::resolutions[_select_res].height > _gui->gameInfo.maxWindowSize.y)

--- a/srcs/scenes/SceneSettings.cpp
+++ b/srcs/scenes/SceneSettings.cpp
@@ -508,6 +508,14 @@ void					SceneSettings::_updateFullscreen() {
 	_fullscreen = !_fullscreen;
 	_updateFullscreenButton();
 	s.j("graphics").b("fullscreen") = _fullscreen;
+	if (_fullscreen) {
+		s.j("graphics").i("width") = _gui->gameInfo.maxWindowSize.x;
+		s.j("graphics").i("height") = _gui->gameInfo.maxWindowSize.y;
+	}
+	else {
+		s.j("graphics").i("width") = _current_resolution.width;
+		s.j("graphics").i("height") = _current_resolution.height;
+	}
 	saveSettings(SETTINGS_FILE);
 	_gui->updateFullscreen();
 }
@@ -526,22 +534,20 @@ void					SceneSettings::_updateResolution(bool go_right) {
 	}
 	_select_res = go_right ? _select_res + 1 : _select_res - 1;
 	if (_select_res < 0) {
-		_select_res = SceneSettings::nb_resolution;
-		if (_custom_res.width == 0 && _custom_res.height == 0) {
-			_select_res--;
-		}
-	}
-	else if (_select_res > SceneSettings::nb_resolution || (_select_res == SceneSettings::nb_resolution \
-			&& _custom_res.width == 0 && _custom_res.height == 0))
-	{
 		_select_res = 0;
 	}
-	if (_select_res == SceneSettings::nb_resolution) {
-		_current_resolution = _custom_res;
+	else if (_select_res > SceneSettings::nb_resolution) {
+		_select_res = SceneSettings::nb_resolution;
 	}
-	else {
-		_current_resolution = SceneSettings::resolutions[_select_res];
+	while (SceneSettings::resolutions[_select_res].width > _gui->gameInfo.maxWindowSize.x
+	|| SceneSettings::resolutions[_select_res].height > _gui->gameInfo.maxWindowSize.y)
+	{
+		if (_select_res > 0)
+			_select_res--;
+		else
+			break;
 	}
+	_current_resolution = SceneSettings::resolutions[_select_res];
 	s.j("graphics").i("width") = _current_resolution.width;
 	s.j("graphics").i("height") = _current_resolution.height;
 	saveSettings(SETTINGS_FILE);

--- a/srcs/utils/opengl/Inputs.cpp
+++ b/srcs/utils/opengl/Inputs.cpp
@@ -468,6 +468,7 @@ void				Inputs::_update() {
 	SDL_Event		event;
 	SDL_Scancode	scan;
 
+	_quit = false;
 	_mouse_rel.x = 0;
 	_mouse_rel.y = 0;
 	_scroll_rel = glm::ivec2(0, 0);

--- a/srcs/utils/opengl/Inputs.cpp
+++ b/srcs/utils/opengl/Inputs.cpp
@@ -10,9 +10,22 @@ const std::string	Inputs::input_type_name[] = {
 	"action_2",
 	"confirm",
 	"cancel",
-	"goto_menu",
-	"show_help",
-	"cheat_code",
+	"menu",
+	"show help",
+	"cheatcode",
+};
+const SDL_Scancode	Inputs::default_keys[] = {
+	DEFAULT_UP,
+	DEFAULT_DOWN,
+	DEFAULT_LEFT,
+	DEFAULT_RIGHT,
+	DEFAULT_ACTION,
+	DEFAULT_ACTION_2,
+	DEFAULT_CONFIRM,
+	DEFAULT_CANCEL,
+	DEFAULT_MENU,
+	DEFAULT_HELP,
+	DEFAULT_CHEATCODE,
 };
 const std::string	Inputs::configFile = "configs/controls.json";
 
@@ -26,27 +39,27 @@ Inputs::Inputs(): _configuring(false), _quit(false), _scroll_rel(0, 0),
 	}
 	_controls.name("controls").description("controls settings");
 	_controls.add<SettingsJson>("keys");
-	_controls.j("keys").add<int64_t>("up", SDL_SCANCODE_UP) \
+	_controls.j("keys").add<int64_t>("up", DEFAULT_UP) \
 		.setMin(4).setMax(286).setDescription("move up.");
-	_controls.j("keys").add<int64_t>("down", SDL_SCANCODE_DOWN) \
+	_controls.j("keys").add<int64_t>("down", DEFAULT_DOWN) \
 		.setMin(4).setMax(286).setDescription("move down.");
-	_controls.j("keys").add<int64_t>("left", SDL_SCANCODE_LEFT) \
+	_controls.j("keys").add<int64_t>("left", DEFAULT_LEFT) \
 		.setMin(4).setMax(286).setDescription("move left.");
-	_controls.j("keys").add<int64_t>("right", SDL_SCANCODE_RIGHT) \
+	_controls.j("keys").add<int64_t>("right", DEFAULT_RIGHT) \
 		.setMin(4).setMax(286).setDescription("move right.");
-	_controls.j("keys").add<int64_t>("action", SDL_SCANCODE_SPACE) \
+	_controls.j("keys").add<int64_t>("action", DEFAULT_ACTION) \
 		.setMin(4).setMax(286).setDescription("action command.");
-	_controls.j("keys").add<int64_t>("action_2", SDL_SCANCODE_B) \
+	_controls.j("keys").add<int64_t>("action_2", DEFAULT_ACTION_2) \
 		.setMin(4).setMax(286).setDescription("action command bonus.");
-	_controls.j("keys").add<int64_t>("confirm", SDL_SCANCODE_RETURN) \
+	_controls.j("keys").add<int64_t>("confirm", DEFAULT_CONFIRM) \
 		.setMin(4).setMax(286).setDescription("confirm choice.");
-	_controls.j("keys").add<int64_t>("cancel", SDL_SCANCODE_ESCAPE) \
+	_controls.j("keys").add<int64_t>("cancel", DEFAULT_CANCEL) \
 		.setMin(4).setMax(286).setDescription("cancel choice.");
-	_controls.j("keys").add<int64_t>("goto_menu", SDL_SCANCODE_TAB) \
+	_controls.j("keys").add<int64_t>("menu", DEFAULT_MENU) \
 		.setMin(4).setMax(286).setDescription("go to menu (buttons).");
-	_controls.j("keys").add<int64_t>("show_help", SDL_SCANCODE_F1) \
+	_controls.j("keys").add<int64_t>("show help", DEFAULT_HELP) \
 		.setMin(4).setMax(286).setDescription("show shortcuts fo buttons");
-	_controls.j("keys").add<int64_t>("cheat_code", SDL_SCANCODE_SLASH) \
+	_controls.j("keys").add<int64_t>("cheatcode", DEFAULT_CHEATCODE) \
 		.setMin(4).setMax(286).setDescription("open cheat code command line");
 	try {
 		if (!_controls.loadFile(Inputs::configFile)) {
@@ -65,9 +78,9 @@ Inputs::Inputs(): _configuring(false), _quit(false), _scroll_rel(0, 0),
 		{ static_cast<SDL_Scancode>(_controls.j("keys").i("action_2")), InputType::ACTION_2 },
 		{ static_cast<SDL_Scancode>(_controls.j("keys").i("confirm")), InputType::CONFIRM },
 		{ static_cast<SDL_Scancode>(_controls.j("keys").i("cancel")), InputType::CANCEL },
-		{ static_cast<SDL_Scancode>(_controls.j("keys").i("goto_menu")), InputType::GOTO_MENU },
-		{ static_cast<SDL_Scancode>(_controls.j("keys").i("show_help")), InputType::SHOW_HELP },
-		{ static_cast<SDL_Scancode>(_controls.j("keys").i("cheat_code")), InputType::CHEAT_CODE },
+		{ static_cast<SDL_Scancode>(_controls.j("keys").i("menu")), InputType::GOTO_MENU },
+		{ static_cast<SDL_Scancode>(_controls.j("keys").i("show help")), InputType::SHOW_HELP },
+		{ static_cast<SDL_Scancode>(_controls.j("keys").i("cheatcode")), InputType::CHEAT_CODE },
 	};
 	_used_scan = {
 		_controls.j("keys").i("up"),
@@ -78,9 +91,9 @@ Inputs::Inputs(): _configuring(false), _quit(false), _scroll_rel(0, 0),
 		_controls.j("keys").i("action_2"),
 		_controls.j("keys").i("confirm"),
 		_controls.j("keys").i("cancel"),
-		_controls.j("keys").i("goto_menu"),
-		_controls.j("keys").i("show_help"),
-		_controls.j("keys").i("cheat_code"),
+		_controls.j("keys").i("menu"),
+		_controls.j("keys").i("show help"),
+		_controls.j("keys").i("cheatcode"),
 	};
 	_controls.saveToFile(Inputs::configFile);
 
@@ -400,6 +413,47 @@ bool				Inputs::getLeftClickDown() {
 
 bool				Inputs::_getLeftClickDown() const {
 	return (_left_click && !_left_click_previous);
+}
+
+/**
+	Reset all the key to their default value.
+*/
+void				Inputs::resetKeys() {
+	Inputs::get()._resetKeys();
+}
+
+void				Inputs::_resetKeys() {
+	logInfo("reset keys");
+	for (auto i = 0; i < InputType::NB_INPUTS; i++) {
+		_controls.j("keys").i(input_type_name[i]) = default_keys[i];
+	}
+	_input_key_map = {
+		{ static_cast<SDL_Scancode>(_controls.j("keys").i("up")), InputType::Enum::UP },
+		{ static_cast<SDL_Scancode>(_controls.j("keys").i("down")), InputType::Enum::DOWN },
+		{ static_cast<SDL_Scancode>(_controls.j("keys").i("left")), InputType::Enum::LEFT },
+		{ static_cast<SDL_Scancode>(_controls.j("keys").i("right")), InputType::Enum::RIGHT },
+		{ static_cast<SDL_Scancode>(_controls.j("keys").i("action")), InputType::Enum::ACTION },
+		{ static_cast<SDL_Scancode>(_controls.j("keys").i("action_2")), InputType::Enum::ACTION_2 },
+		{ static_cast<SDL_Scancode>(_controls.j("keys").i("confirm")), InputType::Enum::CONFIRM },
+		{ static_cast<SDL_Scancode>(_controls.j("keys").i("cancel")), InputType::Enum::CANCEL },
+		{ static_cast<SDL_Scancode>(_controls.j("keys").i("menu")), InputType::Enum::GOTO_MENU },
+		{ static_cast<SDL_Scancode>(_controls.j("keys").i("show help")), InputType::Enum::SHOW_HELP },
+		{ static_cast<SDL_Scancode>(_controls.j("keys").i("cheatcode")), InputType::Enum::CHEAT_CODE },
+	};
+	_used_scan = {
+		_controls.j("keys").i("up"),
+		_controls.j("keys").i("down"),
+		_controls.j("keys").i("left"),
+		_controls.j("keys").i("right"),
+		_controls.j("keys").i("action"),
+		_controls.j("keys").i("action_2"),
+		_controls.j("keys").i("confirm"),
+		_controls.j("keys").i("cancel"),
+		_controls.j("keys").i("menu"),
+		_controls.j("keys").i("show help"),
+		_controls.j("keys").i("cheatcode"),
+	};
+	_controls.saveToFile(Inputs::configFile);
 }
 
 /**

--- a/srcs/utils/opengl/UI/ScrollbarUI.cpp
+++ b/srcs/utils/opengl/UI/ScrollbarUI.cpp
@@ -52,6 +52,9 @@ void ScrollbarUI::_update() {
 		float scrollSizeFactor = getMasterSize().y / _masterTotalSize.y;
 		if (scrollSizeFactor < 0.1) scrollSizeFactor = 0.1;
 		if (scrollSizeFactor > 1) scrollSizeFactor = 1;
+		_vertScrollHide = false;
+		if (scrollSizeFactor == 1)
+			_vertScrollHide = true;
 		_vertScrollBarDrawSize = (_size.y - _borderSize * 2) * scrollSizeFactor;
 
 		// if click on the scroll zone
@@ -100,6 +103,9 @@ void ScrollbarUI::_update() {
 		if (scrollSizeFactor < 0.1) scrollSizeFactor = 0.1;
 		if (scrollSizeFactor > 1) scrollSizeFactor = 1;
 		_horizScrollBarDrawSize = (_size.x - _borderSize * 2) * scrollSizeFactor;
+		_horizScrollHide = false;
+		if (scrollSizeFactor == 1)
+			_horizScrollHide = true;
 
 		// if click on the scroll zone
 		if (_leftClick) {
@@ -151,7 +157,7 @@ void ScrollbarUI::_draw() {
 	glm::vec2 tmpSize;
 
 	// draw scrollbars
-	if (_vertScroll) {
+	if (_vertScroll && !_vertScrollHide) {
 		/* size of the scrollbar */
 		tmpSize.x = _scrollbarSize;
 		tmpSize.y = _vertScrollBarDrawSize;  // height depend to the total master size
@@ -178,7 +184,7 @@ void ScrollbarUI::_draw() {
 		/* draw scrollbar */
 		_drawRect(tmpPos, tmpSize, _z, _scrollbarColor, secColor, factor);
 	}
-	if (_horizScroll) {
+	if (_horizScroll && !_horizScrollHide) {
 		/* size of the scrollbar */
 		tmpSize.y = _scrollbarSize;
 		tmpSize.x = _horizScrollBarDrawSize;  // height depend to the total master size

--- a/srcs/utils/opengl/UI/ScrollbarUI.cpp
+++ b/srcs/utils/opengl/UI/ScrollbarUI.cpp
@@ -52,49 +52,55 @@ void ScrollbarUI::_update() {
 		float scrollSizeFactor = getMasterSize().y / _masterTotalSize.y;
 		if (scrollSizeFactor < 0.1) scrollSizeFactor = 0.1;
 		if (scrollSizeFactor > 1) scrollSizeFactor = 1;
-		_vertScrollHide = false;
-		if (scrollSizeFactor == 1)
-			_vertScrollHide = true;
 		_vertScrollBarDrawSize = (_size.y - _borderSize * 2) * scrollSizeFactor;
 
-		// if click on the scroll zone
-		if (_leftClick) {
-			if (mousePos.x >= getRealPos().x + _size.x - _borderSize - _scrollbarSize
-			&& mousePos.x <= getRealPos().x + _size.x - _borderSize
-			&& mousePos.y >= getRealPos().y + _borderSize
-			&& mousePos.y <= getRealPos().y + _size.y - _borderSize)
-			{
-				_isVertScrollClicked = true;
+		/* show or hide scrollbar */
+		float scrollbarHideFactor = getMasterSize().y / (_masterTotalSize.y - _masterPadding.y * 2);
+		if (scrollbarHideFactor > 1) scrollbarHideFactor = 1;
+		_vertScrollHide = false;
+		if (scrollbarHideFactor == 1)
+			_vertScrollHide = true;
+
+		if (!_vertScrollHide) {
+			// if click on the scroll zone
+			if (_leftClick) {
+				if (mousePos.x >= getRealPos().x + _size.x - _borderSize - _scrollbarSize
+				&& mousePos.x <= getRealPos().x + _size.x - _borderSize
+				&& mousePos.y >= getRealPos().y + _borderSize
+				&& mousePos.y <= getRealPos().y + _size.y - _borderSize)
+				{
+					_isVertScrollClicked = true;
+				}
+				if (_isVertScrollClicked) {
+					// float yMin = getRealPos().y + _borderSize;
+					// float yMax = getRealPos().y + _size.y - (_borderSize * 2);
+					float yMin = getRealPos().y + _borderSize + _vertScrollBarDrawSize / 2;
+					float yMax = getRealPos().y + _size.y - (_borderSize * 2 + _vertScrollBarDrawSize / 2);
+					if (mousePos.y < yMin)
+						_vertScrollbarPos = 1;
+					else if (mousePos.y > yMax)
+						_vertScrollbarPos = 0;
+					else
+						_vertScrollbarPos = 1 - (mousePos.y - yMin) / (yMax - yMin);
+				}
 			}
-			if (_isVertScrollClicked) {
-				// float yMin = getRealPos().y + _borderSize;
-				// float yMax = getRealPos().y + _size.y - (_borderSize * 2);
-				float yMin = getRealPos().y + _borderSize + _vertScrollBarDrawSize / 2;
-				float yMax = getRealPos().y + _size.y - (_borderSize * 2 + _vertScrollBarDrawSize / 2);
-				if (mousePos.y < yMin)
-					_vertScrollbarPos = 1;
-				else if (mousePos.y > yMax)
-					_vertScrollbarPos = 0;
-				else
-					_vertScrollbarPos = 1 - (mousePos.y - yMin) / (yMax - yMin);
+			else {
+				_isVertScrollClicked = false;
 			}
-		}
-		else {
-			_isVertScrollClicked = false;
-		}
-		if (_mouseHover) {
-			// if scrolling
-			if (mouseScroll.y != 0) {
-				float offset = mouseScroll.y * _mouseScrollSpeed * (1 / _masterTotalSize.y);
-				if (_vertScrollInverted)
-					_vertScrollbarPos += offset;
-				else
-					_vertScrollbarPos -= offset;
-				if (_vertScrollbarPos < 0) _vertScrollbarPos = 0;
-				if (_vertScrollbarPos > 1) _vertScrollbarPos = 1;
+			if (_mouseHover) {
+				// if scrolling
+				if (mouseScroll.y != 0) {
+					float offset = mouseScroll.y * _mouseScrollSpeed * (1 / _masterTotalSize.y);
+					if (_vertScrollInverted)
+						_vertScrollbarPos += offset;
+					else
+						_vertScrollbarPos -= offset;
+					if (_vertScrollbarPos < 0) _vertScrollbarPos = 0;
+					if (_vertScrollbarPos > 1) _vertScrollbarPos = 1;
+				}
 			}
+			_masterOffset.y = (_masterTotalSize.y - (_size.y - _borderSize * 2)) * _vertScrollbarPos;
 		}
-		_masterOffset.y = (_masterTotalSize.y - (_size.y - _borderSize * 2)) * _vertScrollbarPos;
 	}
 
 	if (_horizScroll) {
@@ -103,48 +109,54 @@ void ScrollbarUI::_update() {
 		if (scrollSizeFactor < 0.1) scrollSizeFactor = 0.1;
 		if (scrollSizeFactor > 1) scrollSizeFactor = 1;
 		_horizScrollBarDrawSize = (_size.x - _borderSize * 2) * scrollSizeFactor;
+
+		/* show or hide scrollbar */
+		float scrollbarHideFactor = getMasterSize().x / (_masterTotalSize.x - _masterPadding.x * 2);
+		if (scrollbarHideFactor > 1) scrollbarHideFactor = 1;
 		_horizScrollHide = false;
-		if (scrollSizeFactor == 1)
+		if (scrollbarHideFactor == 1)
 			_horizScrollHide = true;
 
-		// if click on the scroll zone
-		if (_leftClick) {
-			if (mousePos.y >= getRealPos().y + _borderSize
-			&& mousePos.y <= getRealPos().y + _borderSize + _scrollbarSize
-			&& mousePos.x >= getRealPos().x + _borderSize
-			&& mousePos.x <= getRealPos().x + _size.x - _borderSize)
-			{
-				_isHorizScrollClicked = true;
+		if (!_horizScrollHide) {
+			// if click on the scroll zone
+			if (_leftClick) {
+				if (mousePos.y >= getRealPos().y + _borderSize
+				&& mousePos.y <= getRealPos().y + _borderSize + _scrollbarSize
+				&& mousePos.x >= getRealPos().x + _borderSize
+				&& mousePos.x <= getRealPos().x + _size.x - _borderSize)
+				{
+					_isHorizScrollClicked = true;
+				}
+				if (_isHorizScrollClicked) {
+					// float xMin = getRealPos().x + _borderSize;
+					// float xMax = getRealPos().x + _size.x - (_borderSize * 2);
+					float xMin = getRealPos().x + _borderSize + _horizScrollBarDrawSize / 2;
+					float xMax = getRealPos().x + _size.x - (_borderSize * 2 + _horizScrollBarDrawSize / 2);
+					if (mousePos.x < xMin)
+						_horizScrollbarPos = 0;
+					else if (mousePos.x > xMax)
+						_horizScrollbarPos = 1;
+					else
+						_horizScrollbarPos = (mousePos.x - xMin) / (xMax - xMin);
+				}
 			}
-			if (_isHorizScrollClicked) {
-				// float xMin = getRealPos().x + _borderSize;
-				// float xMax = getRealPos().x + _size.x - (_borderSize * 2);
-				float xMin = getRealPos().x + _borderSize + _horizScrollBarDrawSize / 2;
-				float xMax = getRealPos().x + _size.x - (_borderSize * 2 + _horizScrollBarDrawSize / 2);
-				if (mousePos.x < xMin)
-					_horizScrollbarPos = 0;
-				else if (mousePos.x > xMax)
-					_horizScrollbarPos = 1;
-				else
-					_horizScrollbarPos = (mousePos.x - xMin) / (xMax - xMin);
+			else {
+				_isHorizScrollClicked = false;
 			}
-		}
-		else {
-			_isHorizScrollClicked = false;
-		}
-		if (_mouseHover) {
-			// if scrolling
-			if (mouseScroll.x != 0) {
-				float offset = mouseScroll.x * _mouseScrollSpeed * (1 / _masterTotalSize.x);
-				if (_horizScrollInverted)
-					_horizScrollbarPos -= offset;
-				else
-					_horizScrollbarPos += offset;
-				if (_horizScrollbarPos < 0) _horizScrollbarPos = 0;
-				if (_horizScrollbarPos > 1) _horizScrollbarPos = 1;
+			if (_mouseHover) {
+				// if scrolling
+				if (mouseScroll.x != 0) {
+					float offset = mouseScroll.x * _mouseScrollSpeed * (1 / _masterTotalSize.x);
+					if (_horizScrollInverted)
+						_horizScrollbarPos -= offset;
+					else
+						_horizScrollbarPos += offset;
+					if (_horizScrollbarPos < 0) _horizScrollbarPos = 0;
+					if (_horizScrollbarPos > 1) _horizScrollbarPos = 1;
+				}
 			}
+			_masterOffset.x = -1 * (_masterTotalSize.x - (_size.x - _borderSize * 2)) * _horizScrollbarPos;
 		}
-		_masterOffset.x = -1 * (_masterTotalSize.x - (_size.x - _borderSize * 2)) * _horizScrollbarPos;
 	}
 }
 


### PR DESCRIPTION
✅ close #140 Quit cancel doesn't work any time
✅ close #53 Rework resolution choice in settings
✅ close #49 add shortcuts in settings
✅ close #112 disable scrollbar if useless
✅ close #101 reload all UI when changing screen resolution (closed by #53)
✅ close #98 update escape key action

## Ajout
- raccourcis claviers pour les settings
- `cmd-q` permet de quit le jeu sans passer par le menu
- bouton `reset` dans le menu pour set les raccourcis claviers
- dans certains menu(settings, levelSelection), escape va renvoyer au menu principal (au lieu d'envoyer au menu quit)
