### PR TITLE
bugfix/multiples-issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,7 @@ SRC =	main.cpp \
 		scenes/SceneSettings.cpp \
 		scenes/SceneCheatCode.cpp \
 		scenes/SceneCheatCode_exec.cpp \
+		scenes/SceneDebug.cpp \
 \
 		audio/AudioManager.cpp \
 		audio/Music.cpp \
@@ -214,6 +215,7 @@ HEAD =	bomberman.hpp \
 		scenes/SceneExit.hpp \
 		scenes/SceneSettings.hpp \
 		scenes/SceneCheatCode.hpp \
+		scenes/SceneDebug.hpp \
 \
 		audio/AudioManager.hpp \
 		audio/Music.hpp \

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,7 @@ SRC =	main.cpp \
 		scenes/SceneSettings.cpp \
 		scenes/SceneCheatCode.cpp \
 		scenes/SceneCheatCode_exec.cpp \
+		scenes/SceneEndGame.cpp \
 \
 		audio/AudioManager.cpp \
 		audio/Music.cpp \
@@ -215,6 +216,7 @@ HEAD =	bomberman.hpp \
 		scenes/SceneExit.hpp \
 		scenes/SceneSettings.hpp \
 		scenes/SceneCheatCode.hpp \
+		scenes/SceneEndGame.hpp \
 \
 		audio/AudioManager.hpp \
 		audio/Music.hpp \

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ SRC =	main.cpp \
 		AEnemy_pathfinding.cpp \
 		elements/Player.cpp \
 \
+		elements/Spawner.cpp \
 		elements/EnemyBasic.cpp \
 		elements/EnemyFollow.cpp \
 		elements/EnemyWithEye.cpp \
@@ -183,6 +184,7 @@ HEAD =	bomberman.hpp \
 		AEnemy.hpp \
 		elements/Player.hpp \
 \
+		elements/Spawner.hpp \
 		elements/EnemyBasic.hpp \
 		elements/EnemyFollow.hpp \
 		elements/EnemyWithEye.hpp \

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ SRC =	main.cpp \
 		gui/Gui.cpp \
 		gui/TextureManager.cpp \
 		gui/ModelsManager.cpp \
+		gui/BoxCollider.cpp \
 \
 		utils/Logging.cpp \
 		utils/SettingsJson.cpp \
@@ -222,6 +223,7 @@ HEAD =	bomberman.hpp \
 		gui/Gui.hpp \
 		gui/TextureManager.hpp \
 		gui/ModelsManager.hpp \
+		gui/BoxCollider.hpp \
 \
 		utils/Logging.hpp \
 		utils/SettingsJson.hpp \

--- a/includes/ACharacter.hpp
+++ b/includes/ACharacter.hpp
@@ -32,8 +32,6 @@ private:
 	glm::vec3	_miniMove(glm::vec3 movement);
 
 protected:
-	glm::vec3	size;
-
 	// Methods
 	std::unordered_set<AEntity *>	_getAllBlockableEntity(glm::vec3 dest) const;
 	bool		_canWalkOnBlock(glm::ivec2 pos) const;

--- a/includes/ACharacter.hpp
+++ b/includes/ACharacter.hpp
@@ -38,8 +38,8 @@ protected:
 	bool		_canWalkOnEntity(AEntity * entity) const;
 	bool		_canMoveOnFromTo(glm::vec3 from, glm::vec3 to) const;
 	bool		_canMoveOn(glm::vec3 dest) const;
-	glm::vec3	_moveTo(Direction::Enum direction, float const offset = OFFSET_TURN_CORRECTION);
-	glm::vec3	_moveTo(glm::vec3 direction, float const offset = OFFSET_TURN_CORRECTION);
+	virtual glm::vec3	_moveTo(Direction::Enum direction, float const offset = OFFSET_TURN_CORRECTION);
+	virtual glm::vec3	_moveTo(glm::vec3 direction, float const offset = OFFSET_TURN_CORRECTION);
 	std::vector<glm::ivec2>	_getAllPositions(glm::vec3 dest, glm::vec3 size) const;
 
 

--- a/includes/ACharacter.hpp
+++ b/includes/ACharacter.hpp
@@ -70,7 +70,7 @@ public:
 	glm::vec3						getPos() const;
 	glm::ivec2						getIntPos() const;
 	ACharacter						*setPosition(glm::vec3 pos);
-	bool							takeDamage(const int damage);
+	virtual bool					takeDamage(const int damage);
 	virtual std::unordered_set<AEntity *>	getCollision(glm::vec3 dest) const;
 	bool							hasCollision(glm::vec3 atPosition, glm::vec3 atSize = glm::vec3(1, 1, 1));
 	bool							tp(glm::vec3 tpPos);

--- a/includes/AEnemy.hpp
+++ b/includes/AEnemy.hpp
@@ -32,9 +32,14 @@ private:
 		glm::ivec2 pos, glm::ivec2 dest, bool & find);
 	bool			_getPathToDFS(glm::ivec2 dest, std::deque<PathNode> & path);
 
+	void			_setMaxSize(bool enable);
+	glm::vec3		_savedSize;
+
 protected:
 	// Members
 	Direction::Enum	_dir;
+	bool			_fisrtCall;  // true until the end of the first update call
+	bool			_moveOnCenter;  // true if the enemy move on center (size < 1)
 
 	virtual bool	_update() = 0;
 	virtual bool	_postUpdate() = 0;

--- a/includes/AEnemy.hpp
+++ b/includes/AEnemy.hpp
@@ -71,6 +71,7 @@ public:
 	bool			postUpdate();
 	bool			draw(Gui &gui);
 	virtual void	animEndCb(std::string animName);
+	virtual bool	takeDamage(const int damage);
 	std::unordered_set<AEntity *>	getCollision(glm::vec3 dest) const;
 
 	// Exceptions

--- a/includes/AEntity.hpp
+++ b/includes/AEntity.hpp
@@ -62,6 +62,7 @@ protected:
 	EntityState::Struct	_entityState;
 	Model				*_model;
 	bool				_animDeathEnd;
+	glm::vec3			size;
 
 public:
 	// Members
@@ -88,6 +89,7 @@ public:
 	virtual bool		update() = 0;
 	virtual bool		postUpdate();
 	virtual bool		draw(Gui &gui) = 0;
+	virtual bool		drawCollider();
 	virtual glm::vec3	getPos() const = 0;
 	virtual bool		takeDamage(const int damage) = 0;
 	virtual std::vector< std::vector< std::vector<AEntity *> > > const &	getBoard() const = 0;

--- a/includes/AEntity.hpp
+++ b/includes/AEntity.hpp
@@ -28,6 +28,7 @@ namespace Type {
 		FLAG,
 		END,
 		BONUS,
+		SPAWNER,
 		ALL,
 		NONE,
 	};

--- a/includes/bomberman.hpp
+++ b/includes/bomberman.hpp
@@ -17,6 +17,11 @@
 
 #define RESTART_TO_UPDATE_RESOLUTION	true  // restart game to reset resolution
 
+#define PLAYER_SIZE			glm::vec3(1.3, 1.3, 1.3)
+#define ENEMY_BASIC_SIZE	glm::vec3(0.7, 0.7, 0.7)
+#define ENEMY_WITH_EYE_SIZE	glm::vec3(1.5, 1.5, 1.5)
+#define ENEMY_FLY_SIZE		glm::vec3(0.7, 0.7, 0.7)
+
 #include <chrono>
 #include "SettingsJson.hpp"
 #include "Logging.hpp"

--- a/includes/elements/Bomb.hpp
+++ b/includes/elements/Bomb.hpp
@@ -5,6 +5,8 @@
 #include <stdexcept>
 #include "AObject.hpp"
 
+#define BOMB_STR "bomb"
+
 /**
  * @brief This is the bomb object
  */

--- a/includes/elements/Crispy.hpp
+++ b/includes/elements/Crispy.hpp
@@ -5,6 +5,8 @@
 #include <stdexcept>
 #include "AObject.hpp"
 
+#define CRISPY_STR "crispy"
+
 class Crispy : public AObject {
 private:
 	Crispy();

--- a/includes/elements/End.hpp
+++ b/includes/elements/End.hpp
@@ -6,6 +6,8 @@
 #include <stdexcept>
 #include "AObject.hpp"
 
+#define END_STR "end"
+
 /**
  * @brief This is the end object
  */

--- a/includes/elements/EnemyBasic.hpp
+++ b/includes/elements/EnemyBasic.hpp
@@ -6,6 +6,8 @@
 #include "AEnemy.hpp"
 #include "SceneGame.hpp"
 
+#define ENEMY_BASIC_STR "enemyBasic"
+
 /**
  * @brief This is an enemy object
  *

--- a/includes/elements/EnemyCrispy.hpp
+++ b/includes/elements/EnemyCrispy.hpp
@@ -6,6 +6,7 @@
 #include "AEnemy.hpp"
 #include "SceneGame.hpp"
 
+#define ENEMY_CRISPY_STR "enemyCrispy"
 #define TIME_BEFORE_TRANSFORM_TO_WALL	8000
 
 /**

--- a/includes/elements/EnemyFly.hpp
+++ b/includes/elements/EnemyFly.hpp
@@ -7,6 +7,7 @@
 #include "SceneGame.hpp"
 
 #define FLY_HEIGHT 1.0
+#define ENEMY_FLY_STR "enemyFly"
 
 /**
  * @brief This is an enemy object

--- a/includes/elements/EnemyFollow.hpp
+++ b/includes/elements/EnemyFollow.hpp
@@ -6,6 +6,8 @@
 #include "AEnemy.hpp"
 #include "SceneGame.hpp"
 
+#define ENEMY_FOLLOW_STR "enemyFollow"
+
 /**
  * @brief This is an enemy object
  *

--- a/includes/elements/EnemyFrog.hpp
+++ b/includes/elements/EnemyFrog.hpp
@@ -6,6 +6,7 @@
 #include "AEnemy.hpp"
 #include "SceneGame.hpp"
 
+#define ENEMY_FROG_STR "enemyFrog"
 #define WAIT_JUMP_TIME_MS		1000
 #define LONG_WAIT_JUMP_TIME_MS	5000
 #define CHANCE_LONG_WAIT		5  // one chance on 5 to have a long wait

--- a/includes/elements/EnemyWithEye.hpp
+++ b/includes/elements/EnemyWithEye.hpp
@@ -6,6 +6,8 @@
 #include "AEnemy.hpp"
 #include "SceneGame.hpp"
 
+#define ENEMY_WITH_EYE_STR "enemyWithEye"
+
 /**
  * @brief This is an enemy object
  *

--- a/includes/elements/Flag.hpp
+++ b/includes/elements/Flag.hpp
@@ -5,6 +5,8 @@
 #include <stdexcept>
 #include "AObject.hpp"
 
+#define FLAG_STR "flag"
+
 /**
  * @brief This is the flag object
  */

--- a/includes/elements/Player.hpp
+++ b/includes/elements/Player.hpp
@@ -8,6 +8,8 @@
 #include "Bonus.hpp"
 #include "Model.hpp"
 
+#define PLAYER_STR "player"
+
 /**
  * @brief This is the player object
  */

--- a/includes/elements/Spawner.hpp
+++ b/includes/elements/Spawner.hpp
@@ -1,0 +1,46 @@
+#ifndef SPAWNER_HPP_
+#define SPAWNER_HPP_
+
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+#include "useGlm.hpp"
+#include "AObject.hpp"
+#include "AEnemy.hpp"
+
+class Spawner : public AObject {
+private:
+	std::vector<std::string>	_typeEnemy;
+	int64_t						_frequency;
+	float						_waitForSpawn;
+
+	Spawner();
+
+public:
+	// Constructors
+	explicit Spawner(SceneGame &game);
+	~Spawner();
+	Spawner(Spawner const &src);
+
+	// Operators
+	Spawner &operator=(Spawner const &rhs);
+
+	// Getters & setters
+	Spawner &setTypeEnemy(std::vector<std::string> typeEnemy);
+	Spawner &addTypeEnemy(std::string typeEnemy);
+	Spawner &setFrequency(int64_t frequency);
+
+	// Methods
+	bool	update();
+	bool	postUpdate();
+	bool	draw(Gui &gui);
+
+	// Exceptions
+	class SpawnerException : public std::runtime_error {
+	public:
+		SpawnerException();
+		explicit SpawnerException(const char* whatArg);
+	};
+};
+
+#endif  // SPAWNER_HPP_

--- a/includes/elements/Wall.hpp
+++ b/includes/elements/Wall.hpp
@@ -5,6 +5,8 @@
 #include <stdexcept>
 #include "AObject.hpp"
 
+#define WALL_STR "wall"
+
 /**
  * @brief This is the wall object
  */

--- a/includes/gui/BoxCollider.hpp
+++ b/includes/gui/BoxCollider.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "useGlm.hpp"
+#include "Gui.hpp"
+#include "Shader.hpp"
+
+#define BOX_SHADER_VS	"shaders/box_collider_vs.glsl"
+#define BOX_SHADER_FS	"shaders/box_collider_fs.glsl"
+
+class BoxCollider {
+	public:
+		BoxCollider();
+		BoxCollider(BoxCollider const & src);
+		virtual ~BoxCollider();
+
+		BoxCollider & operator=(BoxCollider const & rhs);
+
+		static bool				init(Gui * gui);
+		static bool				destroy();
+		static BoxCollider &	get();
+		static bool				drawBox(glm::vec3 pos, glm::vec3 size, glm::vec4 color = {0, 0, 0, 1});
+
+	protected:
+		bool					_init(Gui * gui);
+		bool					_destroy();
+		bool					_drawBox(glm::vec3 pos, glm::vec3 size, glm::vec4 color);
+
+		Gui *				_gui;
+		glm::mat4			_projection;
+		Shader *			_boxShader;
+		uint32_t			_boxShaderVAO;
+		uint32_t			_boxShaderVBO;
+		static const float	_boxVertices[];
+};

--- a/includes/gui/Gui.hpp
+++ b/includes/gui/Gui.hpp
@@ -72,8 +72,6 @@ class Gui {
 
 		Skybox			*_skybox;
 
-		glm::mat4		_projection;
-
 		bool			_exitMenuDisabled;
 
 		static std::array<float, C_FACE_A_SIZE> const		_cubeFaces;

--- a/includes/scenes/SceneCheatCode.hpp
+++ b/includes/scenes/SceneCheatCode.hpp
@@ -79,6 +79,7 @@ class SceneCheatCode : public ASceneMenu {
 		void				setText(std::string const & txt);
 		std::string			getText() const;
 		static bool			isLevelUnlocked(uint32_t levelId);
+		int					unlockLevel(uint32_t levelId);
 
 		/* log */
 		void				logdebug(std::string const & msg, bool clear = false, bool logOnly = false);

--- a/includes/scenes/SceneCheatCode.hpp
+++ b/includes/scenes/SceneCheatCode.hpp
@@ -126,6 +126,7 @@ class SceneCheatCode : public ASceneMenu {
 		int					_execUnlock(std::vector<std::string> const & args);
 		int					_execRmbonus(std::vector<std::string> const & args);
 		int					_execRestart(std::vector<std::string> const & args);
+		int					_execDebug(std::vector<std::string> const & args);
 
 		/* for lines */
 		int					_addLine(std::string const & txt, glm::vec4 txtColor = CHEATCODE_TEXT_COlOR);

--- a/includes/scenes/SceneDebug.hpp
+++ b/includes/scenes/SceneDebug.hpp
@@ -1,0 +1,42 @@
+#ifndef SCENEDEBUG_HPP_
+#define SCENEDEBUG_HPP_
+
+#define DEBUG_FONT			"cheatcode"
+#define DEBUG_FONT_SCALE	1
+#define DEBUG_TEXT_COLOR	glm::vec4(.978, .97, .967, 1)
+
+#define UPDATE_DEBUG_DATA_MS	300
+
+#include <chrono>
+
+#include "ASceneMenu.hpp"
+#include "TextInputUI.hpp"
+
+/**
+ * @brief debug menu to show fps at the top of the screen
+ */
+class SceneDebug : public ASceneMenu {
+	public:
+		// Constructors
+		SceneDebug(Gui *gui, float const &dtTime);
+		virtual ~SceneDebug();
+		SceneDebug(SceneDebug const &src);
+		SceneDebug &operator=(SceneDebug const &rhs);
+
+		// Methods
+		virtual bool		init();
+		virtual bool		update();
+
+		// Setters
+		void	setVisible(bool visible = true);
+
+	private:
+		SceneDebug();
+
+		std::chrono::milliseconds	_lastUpdateMs;
+		bool		_visible;
+		uint16_t	_fps;
+		TextUI		*_fpsText;
+};
+
+#endif  // SCENEDEBUG_HPP_

--- a/includes/scenes/SceneEndGame.hpp
+++ b/includes/scenes/SceneEndGame.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "ASceneMenu.hpp"
+#include "ABaseUI.hpp"
+
+/**
+ * @brief End of the game (after all levels finished)
+ */
+class SceneEndGame : public ASceneMenu {
+	public:
+		// Constructors
+		SceneEndGame(Gui * gui, float const &dtTime);
+		virtual ~SceneEndGame();
+		SceneEndGame(SceneEndGame const &src);
+
+		// Operators
+		SceneEndGame &operator=(SceneEndGame const &rhs);
+		friend std::ostream& operator<<(std::ostream& os, const SceneEndGame& myClass);
+
+		// Methods
+		virtual bool		init();
+		virtual void		load();
+		virtual bool		update();
+		virtual bool		draw();
+
+	protected:
+		struct ButtonsStates {
+			bool	mainMenu;
+			bool	save;
+			bool	exit;
+		};
+		ButtonsStates	_states;
+		struct AllUI {
+			ABaseUI	*mainMenu;
+			ABaseUI	*save;
+			ABaseUI	*exit;
+			ABaseUI	*border;
+		};
+		AllUI		allUI;
+
+
+	private:
+		SceneEndGame();
+		void		_updateUI();
+};

--- a/includes/scenes/SceneEndGame.hpp
+++ b/includes/scenes/SceneEndGame.hpp
@@ -35,6 +35,7 @@ class SceneEndGame : public ASceneMenu {
 			ABaseUI	*save;
 			ABaseUI	*exit;
 			ABaseUI	*border;
+			ABaseUI	*text;
 		};
 		AllUI		allUI;
 

--- a/includes/scenes/SceneEndGame.hpp
+++ b/includes/scenes/SceneEndGame.hpp
@@ -25,17 +25,10 @@ class SceneEndGame : public ASceneMenu {
 
 	protected:
 		struct ButtonsStates {
-			bool	mainMenu;
-			bool	save;
 			bool	exit;
 		};
 		ButtonsStates	_states;
 		struct AllUI {
-			ABaseUI	*mainMenu;
-			ABaseUI	*save;
-			ABaseUI	*exit;
-			ABaseUI	*border;
-			ABaseUI	*text;
 		};
 		AllUI		allUI;
 

--- a/includes/scenes/SceneGame.hpp
+++ b/includes/scenes/SceneGame.hpp
@@ -64,6 +64,7 @@ private:
 		Model *	player;
 		Model *	flower;
 		Model *	robot;
+		Model * fly;
 	};
 	DrawForMenu _menuModels;
 

--- a/includes/scenes/SceneGame.hpp
+++ b/includes/scenes/SceneGame.hpp
@@ -148,6 +148,7 @@ public:
 	bool			drawForMenu();
 	bool			drawVictory();
 	bool			drawGameOver();
+	bool			drawEndGame();
 	bool			loadLevel(int32_t levelId);
 	bool			insertEntity(std::string const & name, glm::ivec2 pos, bool isFly = false, uint64_t wallGenPercent = 0);
 

--- a/includes/scenes/SceneGame.hpp
+++ b/includes/scenes/SceneGame.hpp
@@ -64,8 +64,11 @@ private:
 		Model *	player;
 		Model *	flower;
 		Model *	robot;
+
+		DrawForMenu();
 	};
 	DrawForMenu _menuModels;
+	Model	*_terrain;
 
 	// Methods
 	bool	_loadLevel(int32_t levelId);

--- a/includes/scenes/SceneGame.hpp
+++ b/includes/scenes/SceneGame.hpp
@@ -81,6 +81,7 @@ protected:
 		ABaseUI *	scoreText;  // TextUI
 		ABaseUI *	lifeImg;  // ImageUI
 		ABaseUI *	lifeText;  // TextUI
+		ABaseUI *	enemiesCounterText;  // TextUI
 		ABaseUI *	speedImg;  // ImageUI
 		ABaseUI *	speedText;  // TextUI
 		ABaseUI *	bonusBombImg;  // ImageUI
@@ -97,6 +98,7 @@ protected:
 	AllUI			allUI;
 
 	void			_initGameInfos();
+	void			_loadGameInfos();
 	void			_updateGameInfos();
 	bool			_initBonus();
 
@@ -121,6 +123,8 @@ public:
 	float						levelTime;
 	float						time;
 	Score						score;
+	int64_t						enemiesToKill;
+	int64_t						enemiesKilled;
 
 	// Constructors
 	SceneGame(Gui * gui, float const &dtTime);

--- a/includes/scenes/SceneGame.hpp
+++ b/includes/scenes/SceneGame.hpp
@@ -12,6 +12,7 @@
 #include "ACharacter.hpp"
 #include "Bomb.hpp"
 #include "Score.hpp"
+#include "Spawner.hpp"
 
 #include "ABaseUI.hpp"
 #include "TextUI.hpp"
@@ -22,6 +23,7 @@
 
 class Player;
 class AEnemy;
+class Spawner;
 
 namespace GameState {
 	enum Enum {
@@ -54,7 +56,6 @@ private:
 		EntityType::Enum	entityType;
 		entityFuncPtr		entity;
 	};
-	static std::map<std::string, Entity> _entitiesCall;
 
 	std::vector<SettingsJson *>	_mapsList;
 
@@ -104,6 +105,7 @@ protected:
 
 public:
 	// Members
+	static std::map<std::string, Entity>	entitiesCall;
 	std::vector< std::vector< std::vector<AEntity *> > > board;
 	std::vector< std::vector< std::vector<AEntity *> > > boardFly;
 	Player						*player;
@@ -113,6 +115,7 @@ public:
 		int64_t	nb;
 	};
 	std::unordered_map<std::string, BonusValues>	bonus;
+	std::vector<Spawner *>		spawners;
 
 	int							flags;
 	glm::uvec2					size;

--- a/includes/scenes/SceneManager.hpp
+++ b/includes/scenes/SceneManager.hpp
@@ -20,6 +20,7 @@ namespace SceneNames {
 	static std::string const SETTINGS = "settings";
 	static std::string const LOADGAME = "loadGame";
 	static std::string const CHEAT_CODE = "cheatCode";
+	static std::string const DEBUG_MENU = "debugMenu";
 }  // namespace SceneNames
 
 /**

--- a/includes/scenes/SceneManager.hpp
+++ b/includes/scenes/SceneManager.hpp
@@ -38,6 +38,7 @@ class SceneManager {
 		static AScene *				loadScene(std::string const & name);
 		static AScene *				getScene(std::string const & name);
 		static std::string const &	getSceneName();
+		static uint16_t				getFps();
 		static bool					isSceneChangedInCurFrame();
 		static void					openCheatCode(bool open);
 		static void					openCheatCodeForTime(uint64_t ms);
@@ -58,12 +59,13 @@ class SceneManager {
 		std::string	_scene;  // the name of the current scene
 		std::map<std::string, AScene *>	_sceneMap;  // all scene (in a map)
 		bool		_isInCheatCode;
-		int64_t	_showCheatCodeTextTime;
+		int64_t		_showCheatCodeTextTime;
+		uint16_t	_fps;
 
 		bool		_sceneLoadedCurrentFrame;  // true if a scene was loaded in the current frame
 
 		bool				_init();
-		bool				_run();
+		bool				_run(float maxFrameDuration);
 		bool				_update();
 		bool				_draw();
 		AScene *			_loadScene(std::string const & name);

--- a/includes/scenes/SceneManager.hpp
+++ b/includes/scenes/SceneManager.hpp
@@ -20,6 +20,7 @@ namespace SceneNames {
 	static std::string const SETTINGS = "settings";
 	static std::string const LOADGAME = "loadGame";
 	static std::string const CHEAT_CODE = "cheatCode";
+	static std::string const END_GAME = "endGame";
 }  // namespace SceneNames
 
 /**

--- a/includes/utils/SettingsJson.hpp
+++ b/includes/utils/SettingsJson.hpp
@@ -33,7 +33,7 @@ class JsonObj {
 	public:
 		JsonObj() : _value() { init(); }
 		explicit JsonObj(std::string const & name) : _value() { init(name); }
-		JsonObj(std::string const & name, T const & val) : _value(val) { init(name); }
+		JsonObj(std::string const & name, T const & val) : _value(val), _defVal(val) { init(name); }
 		virtual ~JsonObj() {}
 		JsonObj(JsonObj const & src) { *this = src; }
 		JsonObj & operator=(JsonObj const & rhs) {
@@ -90,6 +90,9 @@ class JsonObj {
 		JsonObj<T> &		setDescription(std::string const & desc) { _description = desc; return *this; }
 		JsonObj<T> &		disableInFile(bool disable = true) { _disableInFile = disable; return *this; }
 		bool				isDisabledInFile() { return _disableInFile; }
+		void				setDefVal(T val) { _defVal = val; }
+		T					getDefVal() const { return _defVal; }
+		void				reset() { _value = _defVal; }
 		void				setName(std::string const & name) { _name = name; }
 		std::string	&		getName() { return _name; }
 		std::string	const &	getName() const { return _name; }
@@ -134,6 +137,7 @@ class JsonObj {
 		bool		_hasMax;
 		T			_max;
 		bool		_disableInFile;
+		T			_defVal;
 };
 
 /**

--- a/includes/utils/opengl/Camera.hpp
+++ b/includes/utils/opengl/Camera.hpp
@@ -115,8 +115,8 @@ class Camera {
 		/* frustum culling */
 		// to test if objects are inside or outside of the camera
 		void	frustumCullingInit(CAMERA_FLOAT angleDeg, CAMERA_FLOAT ratio, CAMERA_FLOAT nearD, CAMERA_FLOAT farD);
-		int		frustumCullingCheckPoint(CAMERA_VEC3 const &point);  // check if a point is inside the camera
-		int		frustumCullingCheckCube(CAMERA_VEC3 const &startPoint, CAMERA_VEC3 &size);  // check for a cube
+		int		frustumCullingCheckPoint(CAMERA_VEC3 const &point) const;  // check if a point is inside the camera
+		int		frustumCullingCheckCube(CAMERA_VEC3 const &startPoint, CAMERA_VEC3 const &size) const;  // check for a cube
 
 		/* follow path */
 		void	setFollowPath(std::vector<CamPoint> const & path);

--- a/includes/utils/opengl/Camera.hpp
+++ b/includes/utils/opengl/Camera.hpp
@@ -119,6 +119,7 @@ class Camera {
 		int		frustumCullingCheckCube(CAMERA_VEC3 const &startPoint, CAMERA_VEC3 &size);  // check for a cube
 
 		/* follow path */
+		void	resetFollowPath();
 		void	setFollowPath(std::vector<CamPoint> const & path);
 		void	setFollowRepeat(bool repeat);
 		void	setFollowSpeed(float speed_);

--- a/includes/utils/opengl/Mesh.hpp
+++ b/includes/utils/opengl/Mesh.hpp
@@ -11,6 +11,8 @@
 #include "Shader.hpp"
 #include "Material.hpp"
 
+class OpenGLModel;
+
 namespace TextureType {
 	enum Enum {
 		DIFFUSE,
@@ -34,6 +36,11 @@ struct	Vertex {
 	Vertex();  // default constructor, init bonesId and bonesW
 };
 
+struct	BoundingBox {
+	glm::vec3	startPoint;
+	glm::vec3	size;
+};
+
 struct	Texture {
 	uint32_t			id;
 	TextureType::Enum	type;
@@ -46,14 +53,14 @@ struct	Texture {
  */
 class	Mesh {
 	public:
-		Mesh(Shader &sh, std::string const &name, std::vector<Vertex> vertices,
+		Mesh(OpenGLModel &openGLModel, Shader &sh, std::string const &name, std::vector<Vertex> vertices,
 			std::vector<uint32_t> vertIndices, std::vector<Texture> textures,
-			Material material);
+			Material material, BoundingBox boundingBox);
 		virtual ~Mesh();
 		Mesh(Mesh const &src);
 		Mesh &operator=(Mesh const &rhs);
 
-		void	draw() const;
+		void	draw(glm::mat4 const &model) const;
 		void	addBoneData(uint32_t boneID, float weight, uint32_t VerticeID);
 		void	sendMesh();
 
@@ -61,12 +68,14 @@ class	Mesh {
 		Mesh();  // private default constructor, should not be called
 		void	_setUniformsTextures() const;
 
+		OpenGLModel				&_openGLModel;
 		Shader					&_sh;
 		std::string				_name;
 		std::vector<Vertex>		_vertices;
 		std::vector<uint32_t>	_vertIndices;  // contain _vertices id
 		std::vector<Texture>	_textures;
 		Material				_material;
+		BoundingBox				_boundingBox;
         uint32_t				_vao;
         uint32_t				_vbo;
         uint32_t				_ebo;

--- a/includes/utils/opengl/OpenGLModel.hpp
+++ b/includes/utils/opengl/OpenGLModel.hpp
@@ -32,6 +32,17 @@ namespace AnimKeyType {
 	}};
 }  // namespace AnimKeyType
 
+struct	VerticesLimits {
+	float	xMin;
+	float	xMax;
+	float	yMin;
+	float	yMax;
+	float	zMin;
+	float	zMax;
+
+	VerticesLimits();
+};
+
 /**
  * @brief class to load and draw a 3d model from file
  *
@@ -53,6 +64,7 @@ class OpenGLModel {
 		bool		isAnimated() const;
 		std::vector<std::string>	getAnimationNames() const;
 		uint32_t	getNbAnimations() const;
+		Camera const	&getCam() const;
 
 		// Exceptions
 		class ModelException : public std::runtime_error {

--- a/includes/utils/opengl/Skybox.hpp
+++ b/includes/utils/opengl/Skybox.hpp
@@ -10,7 +10,7 @@
 
 #define SKYBOX_USING 0
 #if SKYBOX_USING == 0
-	#define SKYBOX_START	"./bomberman-assets/skybox/cartoonSky/"
+	#define SKYBOX_START	"./bomberman-assets/skybox/bomberSky/"
 	#define SKYBOX_EXT		".jpg"
 	#define SKYBOX_NAME_TYPE 2
 #endif

--- a/shaders/box_collider_fs.glsl
+++ b/shaders/box_collider_fs.glsl
@@ -1,0 +1,10 @@
+#version 410 core
+
+uniform vec4 color;
+
+out vec4 fragColor;
+
+void main()
+{
+    fragColor = color;
+}

--- a/shaders/box_collider_vs.glsl
+++ b/shaders/box_collider_vs.glsl
@@ -1,0 +1,11 @@
+#version 410 core
+
+layout (location = 0) in vec3 aPos;
+
+uniform mat4 model;
+uniform mat4 view;
+uniform mat4 projection;
+
+void main() {
+	gl_Position = projection * view * model * vec4(aPos, 1.0);
+}

--- a/srcs/ACharacter.cpp
+++ b/srcs/ACharacter.cpp
@@ -7,13 +7,13 @@
 
 ACharacter::ACharacter(SceneGame &game)
 : AEntity(game),
-  size(0.95, 1.5, 0.95),
   front(0, 0, 1)
 {
 	category = Category::MOBILE;
 	lives = 1;
 	speed = 1.0;
 	position = {0.0, 0.0, 0.0};
+	size = {0.95, 1.5, 0.95};
 	blockPropagation = false;
 	destructible = true;
 	resetCrossable();

--- a/srcs/AEnemy.cpp
+++ b/srcs/AEnemy.cpp
@@ -113,6 +113,25 @@ void	AEnemy::animEndCb(std::string animName) {
 }
 
 /**
+ * @brief AEnemy Take <damage> damages.
+ *
+ * @param damage
+ * @return true if damage taken
+ * @return false if damage not taken
+ */
+bool	AEnemy::takeDamage(const int damage) {
+	bool	wasAlive = alive;
+	bool	result = ACharacter::takeDamage(damage);
+	if (result) {
+		if (wasAlive && !alive) {
+			game.enemiesKilled += 1;
+		}
+	}
+
+	return result;
+}
+
+/**
  * @brief get a list of entity in collision with the Character at a position.
  *
  * @param pos default VOID_POS3

--- a/srcs/AEnemy.cpp
+++ b/srcs/AEnemy.cpp
@@ -1,6 +1,7 @@
 #include <stack>
 #include "AEnemy.hpp"
 #include "Player.hpp"
+#include "EnemyFly.hpp"
 
 // -- Constructors -------------------------------------------------------------
 
@@ -65,7 +66,7 @@ bool	AEnemy::update() {
 		setState(EntityState::ATTACK);
 
 		// facing player on attack (except for EnemyFly)
-		if (name != "EnemyFly") {
+		if (name != ENEMY_FLY_STR) {
 			front = glm::normalize(game.player->position - position);
 		}
 	}
@@ -139,7 +140,7 @@ bool	AEnemy::takeDamage(const int damage) {
  */
 std::unordered_set<AEntity *>	AEnemy::getCollision(glm::vec3 dest) const {
 	std::unordered_set<AEntity *> collisions = ACharacter::getCollision(dest);
-	if (name == "EnemyFly")
+	if (name == ENEMY_FLY_STR)
 		return collisions;
 
 	/* get all positions blocks under character on a position */
@@ -149,7 +150,7 @@ std::unordered_set<AEntity *>	AEnemy::getCollision(glm::vec3 dest) const {
 	for (auto enemy : game.enemies) {
 		if (enemy == this)
 			continue;
-		if (enemy->name == "EnemyFly")
+		if (enemy->name == ENEMY_FLY_STR)
 			continue;
 		allPosEnemy.clear();
 		allPosEnemy = _getAllPositions(enemy->getPos(), enemy->size );

--- a/srcs/AEntity.cpp
+++ b/srcs/AEntity.cpp
@@ -1,10 +1,12 @@
 #include "AEntity.hpp"
 #include "SceneGame.hpp"
 #include "Model.hpp"
+#include "BoxCollider.hpp"
 
 // -- Constructors -------------------------------------------------------------
 
 AEntity::AEntity(SceneGame &game): game(game) {
+	size = {1, 1, 1};
 	active = true;
 	alive = true;
 	position = VOID_POS3;
@@ -38,6 +40,17 @@ bool		AEntity::init() {
 }
 
 bool		AEntity::postUpdate() {
+	return true;
+}
+
+/**
+ * @brief Draw the collider of the entity
+ *
+ * @return false If failed
+ */
+bool		AEntity::drawCollider() {
+	glm::vec4 color = colorise(s.j("colors").j("collider").u("color"), s.j("colors").j("collider").u("alpha"));
+	BoxCollider::drawBox(position, size, color);
 	return true;
 }
 

--- a/srcs/bomberman.cpp
+++ b/srcs/bomberman.cpp
@@ -196,12 +196,13 @@ bool	initSettings(std::string const & filename) {
 
 	/* Debug */
 	s.add<SettingsJson>("debug").setDescription("All debug settings");
-		s.j("debug").add<bool>("showBaseBoard", true).setDescription("Show the base board");
-		s.j("debug").add<bool>("showEntity", true).setDescription("Show the entities (player & enemy)");
-		s.j("debug").add<bool>("showFlyHeight", false).setDescription("Show the fly height");
-		s.j("debug").add<bool>("showMovingCollider", false).setDescription("Show the collider of moving entities");
-		s.j("debug").add<bool>("showStaticCollider", false).setDescription("Show the collider of static entities");
 		s.j("debug").add<bool>("3d-menu", true).setDescription("Use 3D menu");
+		s.j("debug").add<SettingsJson>("show").setDescription("All showables settings for command /debug");
+			s.j("debug").j("show").add<bool>("baseBoard", true).setDescription("Show the base board");
+			s.j("debug").j("show").add<bool>("entity", true).setDescription("Show the entities (player & enemy)");
+			s.j("debug").j("show").add<bool>("flyHeight", false).setDescription("Show the fly height");
+			s.j("debug").j("show").add<bool>("movingCollider", false).setDescription("Show the collider of moving entities");
+			s.j("debug").j("show").add<bool>("staticCollider", false).setDescription("Show the collider of static entities");
 
 	try {
 		if (file::isDir(filename)) {

--- a/srcs/bomberman.cpp
+++ b/srcs/bomberman.cpp
@@ -158,6 +158,11 @@ bool	initSettings(std::string const & filename) {
 		s.j("colors").j("bg-rect-border").add<uint64_t>("color", 0x155c2c).setMin(0x000000).setMax(0xFFFFFF);
 		s.j("colors").j("bg-rect-border").add<uint64_t>("alpha", 0xFF).setMin(0x00).setMax(0xFF);
 
+	// collider
+	s.j("colors").add<SettingsJson>("collider");
+		s.j("colors").j("collider").add<uint64_t>("color", 0x155c2c).setMin(0x000000).setMax(0xFFFFFF);
+		s.j("colors").j("collider").add<uint64_t>("alpha", 0xFF).setMin(0x00).setMax(0xFF);
+
 	/* Audio */
 	s.add<SettingsJson>("audio");
 	s.j("audio").add<double>("Master volume", 1.0).setMin(0.0).setMax(1.0) \
@@ -194,6 +199,8 @@ bool	initSettings(std::string const & filename) {
 		s.j("debug").add<bool>("showBaseBoard", true).setDescription("Show the base board");
 		s.j("debug").add<bool>("showEntity", true).setDescription("Show the entities (player & enemy)");
 		s.j("debug").add<bool>("showFlyHeight", false).setDescription("Show the fly height");
+		s.j("debug").add<bool>("showMovingCollider", false).setDescription("Show the collider of moving entities");
+		s.j("debug").add<bool>("showStaticCollider", false).setDescription("Show the collider of static entities");
 		s.j("debug").add<bool>("3d-menu", true).setDescription("Use 3D menu");
 
 	try {

--- a/srcs/elements/Bomb.cpp
+++ b/srcs/elements/Bomb.cpp
@@ -7,7 +7,7 @@
 
 Bomb::Bomb(SceneGame &game) : AObject(game) {
 	type = Type::BOMB;
-	name = "Bomb";
+	name = BOMB_STR;
 	_countdown = 2.0f;
 	_propagation = 3;
 	blockPropagation = true;

--- a/srcs/elements/Crispy.cpp
+++ b/srcs/elements/Crispy.cpp
@@ -7,7 +7,7 @@
 
 Crispy::Crispy(SceneGame &game) : AObject(game) {
 	type = Type::CRISPY;
-	name = "Crispy";
+	name = CRISPY_STR;
 	destructible = true;
 }
 

--- a/srcs/elements/End.cpp
+++ b/srcs/elements/End.cpp
@@ -37,16 +37,18 @@ End &End::operator=(End const &rhs) {
  */
 bool	End::update() {
 	if (game.flags <= 0) {
-		_texture = Block::END_OPEN;
-		if (std::find(game.player->crossableTypes.begin(), game.player->crossableTypes.end(), Type::END)
-		== game.player->crossableTypes.end())
-		{
-			game.player->crossableTypes.push_back(Type::END);
-		}
-		std::unordered_set<AEntity *> collisions = _getCollision();
-		for (auto &&entity : collisions) {
-			if (entity->type == Type::PLAYER) {
-				game.state = GameState::WIN;
+		if (game.enemiesToKill <= game.enemiesKilled) {
+			_texture = Block::END_OPEN;
+			if (std::find(game.player->crossableTypes.begin(), game.player->crossableTypes.end(), Type::END)
+			== game.player->crossableTypes.end())
+			{
+				game.player->crossableTypes.push_back(Type::END);
+			}
+			std::unordered_set<AEntity *> collisions = _getCollision();
+			for (auto &&entity : collisions) {
+				if (entity->type == Type::PLAYER) {
+					game.state = GameState::WIN;
+				}
 			}
 		}
 	}

--- a/srcs/elements/End.cpp
+++ b/srcs/elements/End.cpp
@@ -6,7 +6,7 @@
 
 End::End(SceneGame &game) : AObject(game) {
 	type = Type::END;
-	name = "End";
+	name = END_STR;
 	_texture = Block::END;
 }
 

--- a/srcs/elements/EnemyBasic.cpp
+++ b/srcs/elements/EnemyBasic.cpp
@@ -148,8 +148,7 @@ bool	EnemyBasic::init() {
 			delete _model;
 
 		OpenGLModel	&openglModel = ModelsManager::getModel("robot");
-		_model = new Model(openglModel, game.getDtTime(), ETransform({0, 0, 0},
-			{.7, .7, .7}));
+		_model = new Model(openglModel, game.getDtTime(), ETransform({0, 0, 0}, ENEMY_BASIC_SIZE));
 		_model->play = true;
 		_model->loopAnimation = true;
 		_model->setAnimation("Armature|idle");

--- a/srcs/elements/EnemyBasic.cpp
+++ b/srcs/elements/EnemyBasic.cpp
@@ -7,7 +7,7 @@ EnemyBasic::EnemyBasic(SceneGame &game)
 : AEnemy(game)
 {
 	size = glm::vec3(0.85, 1.0, 0.85);
-	name = "EnemyBasic";
+	name = ENEMY_BASIC_STR;
 }
 
 EnemyBasic::~EnemyBasic() {

--- a/srcs/elements/EnemyBasic.cpp
+++ b/srcs/elements/EnemyBasic.cpp
@@ -6,8 +6,8 @@
 EnemyBasic::EnemyBasic(SceneGame &game)
 : AEnemy(game)
 {
-	size = glm::vec3(0.85, 1.0, 0.85);
 	name = "EnemyBasic";
+	size = glm::vec3(0.7, 1.0, 0.7);
 }
 
 EnemyBasic::~EnemyBasic() {

--- a/srcs/elements/EnemyCrispy.cpp
+++ b/srcs/elements/EnemyCrispy.cpp
@@ -9,7 +9,7 @@ EnemyCrispy::EnemyCrispy(SceneGame &game)
   _playerDir(Direction::NO_DIRECTION),
   _lastPayerSeenMs(0)
 {
-	name = "EnemyCrispy";
+	name = ENEMY_CRISPY_STR;
 }
 
 EnemyCrispy::~EnemyCrispy() {

--- a/srcs/elements/EnemyFly.cpp
+++ b/srcs/elements/EnemyFly.cpp
@@ -6,7 +6,7 @@
 EnemyFly::EnemyFly(SceneGame &game)
 : AEnemy(game)
 {
-	name = "EnemyFly";
+	name = ENEMY_FLY_STR;
 	size = glm::vec3(.8, .8, .8);
 }
 

--- a/srcs/elements/EnemyFly.cpp
+++ b/srcs/elements/EnemyFly.cpp
@@ -157,7 +157,7 @@ bool	EnemyFly::init() {
 
 		OpenGLModel	&openglModel = ModelsManager::getModel("flyingBot");
 		_model = new Model(openglModel, game.getDtTime(), ETransform({1.5,
-			FLY_HEIGHT, 1.5}, {.7, .7, .7}));
+			FLY_HEIGHT, 1.5}, ENEMY_FLY_SIZE));
 		_model->play = true;
 		_model->loopAnimation = true;
 		_model->setAnimation("Armature|run");

--- a/srcs/elements/EnemyFollow.cpp
+++ b/srcs/elements/EnemyFollow.cpp
@@ -8,7 +8,7 @@ EnemyFollow::EnemyFollow(SceneGame &game)
   _findPlayer(false),
   _path()
 {
-	name = "EnemyFollow";
+	name = ENEMY_FOLLOW_STR;
 	size = glm::vec3(0.8, 1.5, 0.8);
 	_lastFindMs = getMs();
 }

--- a/srcs/elements/EnemyFrog.cpp
+++ b/srcs/elements/EnemyFrog.cpp
@@ -8,7 +8,7 @@ EnemyFrog::EnemyFrog(SceneGame &game)
   _jumpGoal(VOID_POS),
   _nextJumpTime(0)
 {
-	name = "EnemyFrog";
+	name = ENEMY_FROG_STR;
 	size = glm::vec3(0.7, 0.5, 0.7);
 	strength = 0;  // remove auto damage
 	resetCrossable();

--- a/srcs/elements/EnemyWithEye.cpp
+++ b/srcs/elements/EnemyWithEye.cpp
@@ -43,8 +43,7 @@ bool	EnemyWithEye::init() {
 			delete _model;
 
 		OpenGLModel	&openglModel = ModelsManager::getModel("flower");
-		_model = new Model(openglModel, game.getDtTime(), ETransform({0, 0, 0},
-			{1.5, 1.5, 1.5}));
+		_model = new Model(openglModel, game.getDtTime(), ETransform({0, 0, 0}, ENEMY_WITH_EYE_SIZE));
 		_model->play = true;
 		_model->loopAnimation = true;
 		_model->setAnimation("Armature|idle");

--- a/srcs/elements/EnemyWithEye.cpp
+++ b/srcs/elements/EnemyWithEye.cpp
@@ -7,7 +7,7 @@ EnemyWithEye::EnemyWithEye(SceneGame &game)
 : AEnemy(game),
   _playerDir(Direction::NO_DIRECTION)
 {
-	name = "EnemyWithEye";
+	name = ENEMY_WITH_EYE_STR;
 }
 
 EnemyWithEye::~EnemyWithEye() {

--- a/srcs/elements/EnemyWithEye.cpp
+++ b/srcs/elements/EnemyWithEye.cpp
@@ -8,6 +8,7 @@ EnemyWithEye::EnemyWithEye(SceneGame &game)
   _playerDir(Direction::NO_DIRECTION)
 {
 	name = "EnemyWithEye";
+	size = glm::vec3(0.7, 1.0, 0.7);
 }
 
 EnemyWithEye::~EnemyWithEye() {

--- a/srcs/elements/Flag.cpp
+++ b/srcs/elements/Flag.cpp
@@ -5,7 +5,7 @@
 
 Flag::Flag(SceneGame &game) : AObject(game) {
 	type = Type::FLAG;
-	name = "Flag";
+	name = FLAG_STR;
 	destructible = true;
 	blockPropagation = true;
 }

--- a/srcs/elements/Player.cpp
+++ b/srcs/elements/Player.cpp
@@ -8,7 +8,7 @@ Player::Player(SceneGame &game)
 	_model = nullptr;
 	size = glm::vec3(0.7, 1.5, 0.7);
 	type = Type::PLAYER;
-	name = "Player";
+	name = PLAYER_STR;
 	resetParams();
 }
 

--- a/srcs/elements/Player.cpp
+++ b/srcs/elements/Player.cpp
@@ -58,7 +58,7 @@ bool	Player::init() {
 		}
 
 		OpenGLModel	&openglModel = ModelsManager::getModel("white");
-		_model = new Model(openglModel, game.getDtTime(), ETransform(tmpPos, {1.3, 1.3, 1.3}));
+		_model = new Model(openglModel, game.getDtTime(), ETransform(tmpPos, PLAYER_SIZE));
 		_model->play = true;
 		_model->loopAnimation = true;
 		_model->setAnimation("Armature|idle", &AEntity::animEndCb, this);

--- a/srcs/elements/Spawner.cpp
+++ b/srcs/elements/Spawner.cpp
@@ -1,0 +1,121 @@
+#include "Spawner.hpp"
+#include "SceneGame.hpp"
+#include "Player.hpp"
+#include "Bonus.hpp"
+
+#include "EnemyBasic.hpp"
+#include "EnemyFollow.hpp"
+#include "EnemyWithEye.hpp"
+#include "EnemyFly.hpp"
+#include "EnemyCrispy.hpp"
+#include "EnemyFrog.hpp"
+
+// -- Constructors -------------------------------------------------------------
+
+Spawner::Spawner(SceneGame &game) : AObject(game) {
+	type = Type::SPAWNER;
+	name = "Spawner";
+	destructible = false;
+	blockPropagation = false;
+	// _typeEnemy = std::vector<std::string>();
+	_frequency = 0;
+	_waitForSpawn = 0;
+}
+
+Spawner::~Spawner() {
+}
+
+Spawner::Spawner(Spawner const &src) : AObject(src) {
+	*this = src;
+}
+
+// -- Operators ----------------------------------------------------------------
+
+Spawner &Spawner::operator=(Spawner const &rhs) {
+	if ( this != &rhs ) {
+		AObject::operator=(rhs);
+		_typeEnemy = rhs._typeEnemy;
+		_frequency = rhs._frequency;
+		_waitForSpawn = rhs._waitForSpawn;
+	}
+	return *this;
+}
+
+// -- Getter & setters ---------------------------------------------------------
+
+Spawner &Spawner::setTypeEnemy(std::vector<std::string> typeEnemy) {
+	_typeEnemy.clear();
+	_typeEnemy = typeEnemy;
+	return *this;
+}
+
+Spawner &Spawner::addTypeEnemy(std::string typeEnemy) {
+	std::vector<std::string>::iterator it = std::find(_typeEnemy.begin(), _typeEnemy.end(), typeEnemy);
+	if (it == _typeEnemy.end()) {
+		_typeEnemy.push_back(typeEnemy);
+	}
+	return *this;
+}
+
+Spawner &Spawner::setFrequency(int64_t frequency) {
+	_frequency = frequency;
+	return *this;
+}
+
+// -- Methods ------------------------------------------------------------------
+
+/**
+ * @brief update is called each frame.
+ *
+ * @return true if success
+ * @return false if failure
+ */
+bool	Spawner::update() {
+	if (!active)
+		return true;
+	if (!alive) {
+		active = false;
+		return true;
+	}
+	if (_frequency == 0)
+		return true;
+
+	_waitForSpawn -= game.getDtTime();
+	if (_waitForSpawn < 0) {
+		int enemyKind = rand() % _typeEnemy.size();
+		bool fly = _typeEnemy[enemyKind] == ENEMY_FLY_STR ? true : false;
+		if (game.insertEntity(_typeEnemy[enemyKind], {position.x, position.z}, fly, 0)) {
+			// reset for new spawn
+			_waitForSpawn = _frequency;
+		} else {
+			// wait a little more time to spawn
+			_waitForSpawn = 1;
+		}
+	}
+
+	return true;
+}
+
+bool	Spawner::postUpdate() {
+	return true;
+}
+
+/**
+ * @brief draw is called each frame.
+ *
+ * @return true if success
+ * @return false if failure
+ */
+bool	Spawner::draw(Gui &gui) {
+	(void)gui;
+	return true;
+}
+
+
+// -- Exceptions errors --------------------------------------------------------
+
+Spawner::SpawnerException::SpawnerException()
+: std::runtime_error("Spawner Exception") {}
+
+Spawner::SpawnerException::SpawnerException(const char* whatArg)
+: std::runtime_error(std::string(std::string("SpawnerError: ") + whatArg).c_str()) {}

--- a/srcs/elements/Wall.cpp
+++ b/srcs/elements/Wall.cpp
@@ -7,7 +7,7 @@ Wall::Wall(SceneGame &game, Block::Enum blockType)
 : AObject(game), _blockType(blockType)
 {
 	type = Type::WALL;
-	name = "Wall";
+	name = WALL_STR;
 }
 
 Wall::~Wall() {

--- a/srcs/gui/BoxCollider.cpp
+++ b/srcs/gui/BoxCollider.cpp
@@ -1,0 +1,147 @@
+#include "BoxCollider.hpp"
+#include "Logging.hpp"
+
+const float	BoxCollider::_boxVertices[] = {
+	0, 0, 0,
+	0, 0, 1,
+
+	1, 0, 0,
+	1, 0, 1,
+
+	0, 0, 0,
+	1, 0, 0,
+
+	0, 0, 1,
+	1, 0, 1,
+
+	0, 1, 0,
+	0, 1, 1,
+
+	1, 1, 0,
+	1, 1, 1,
+
+	0, 1, 0,
+	1, 1, 0,
+
+	0, 1, 1,
+	1, 1, 1,
+
+	0, 0, 0,
+	0, 1, 0,
+
+	0, 0, 1,
+	0, 1, 1,
+
+	1, 0, 0,
+	1, 1, 0,
+
+	1, 0, 1,
+	1, 1, 1,
+};
+
+BoxCollider::BoxCollider()
+: _gui(nullptr),
+  _boxShader(nullptr) {}
+
+BoxCollider::BoxCollider(BoxCollider const & src) {
+	*this = src;
+}
+
+BoxCollider::~BoxCollider() {
+}
+
+/**
+ * @brief Init the BoxCollider object (call only once)
+ *
+ * @return false If failed
+ */
+bool BoxCollider::init(Gui * gui) {
+	return BoxCollider::get()._init(gui);
+}
+bool BoxCollider::_init(Gui * gui) {
+	_gui = gui;
+	_boxShader = new Shader(BOX_SHADER_VS, BOX_SHADER_FS);
+	_boxShader->use();
+	_boxShader->setMat4("projection", _gui->cam->getProjection());
+    glGenVertexArrays(1, &_boxShaderVAO);
+    glGenBuffers(1, &_boxShaderVBO);
+
+    glBindVertexArray(_boxShaderVAO);
+    glBindBuffer(GL_ARRAY_BUFFER, _boxShaderVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(BoxCollider::_boxVertices), BoxCollider::_boxVertices, GL_STATIC_DRAW);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), reinterpret_cast<void*>(0));
+    glEnableVertexAttribArray(0);
+
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindVertexArray(0);
+	_boxShader->unuse();
+	return true;
+}
+
+/**
+ * @brief Destroy the BoxCollider object (call only once)
+ *
+ * @return false If failed
+ */
+bool BoxCollider::destroy() {
+	return BoxCollider::get()._destroy();
+}
+bool BoxCollider::_destroy() {
+	if (_boxShader == nullptr) {
+		logErr("you need to init BoxCollider before destroy it");
+		return false;
+	}
+	glBindVertexArray(0);
+	glDeleteVertexArrays(1, &_boxShaderVAO);
+	glBindBuffer(GL_ARRAY_BUFFER, 0);
+	glDeleteBuffers(1, &_boxShaderVBO);
+	delete _boxShader;
+	_boxShader = nullptr;
+	return true;
+}
+
+BoxCollider & BoxCollider::operator=(BoxCollider const & rhs) {
+	if (this != &rhs) {
+		logWarn("BoxCollider object copied");
+	}
+	return *this;
+}
+
+/**
+ * @brief Get the instance of BoxCollider object
+ *
+ * @return BoxCollider& The instance
+ */
+BoxCollider &	BoxCollider::get() {
+	static BoxCollider	instance;
+	return instance;
+}
+
+/**
+ * @brief Draw a box collider on the screen
+ *
+ * @param pos The position
+ * @param size The size
+ * @param color The color
+ */
+bool BoxCollider::drawBox(glm::vec3 pos, glm::vec3 size, glm::vec4 color) {
+	return BoxCollider::get()._drawBox(pos, size, color);
+}
+bool BoxCollider::_drawBox(glm::vec3 pos, glm::vec3 size, glm::vec4 color) {
+	if (_boxShader == nullptr) {
+		logErr("You need to init BoxCollider before draw (BoxCollider::init)");
+		return false;
+	}
+	glm::mat4 model = glm::mat4(1.0);
+	model = glm::translate(model, pos);
+	model = glm::scale(model, size);
+	_boxShader->use();
+	_boxShader->setMat4("view", _gui->cam->getViewMatrix());
+	_boxShader->setMat4("model", model);
+	_boxShader->setVec4("color", color);
+	glBindVertexArray(_boxShaderVAO);
+	glDrawArrays(GL_LINES, 0, 24);
+	glBindVertexArray(0);
+	_boxShader->unuse();
+	return true;
+}

--- a/srcs/gui/Gui.cpp
+++ b/srcs/gui/Gui.cpp
@@ -4,6 +4,7 @@
 #include "SceneManager.hpp"
 #include "Material.hpp"
 #include "ABaseUI.hpp"
+#include "BoxCollider.hpp"
 
 // -- Gui ---------------------------------------------------------------
 Gui::Gui(GameInfo &gameInfo)
@@ -35,6 +36,7 @@ Gui::~Gui() {
 	delete _skybox;
 
 	ABaseUI::destroy();
+	BoxCollider::destroy();
 
 	// properly quit sdl
 	SDL_GL_DeleteContext(_context);
@@ -149,6 +151,10 @@ bool	Gui::init() {
 	}
 	catch (ABaseUI::UIException const & e) {
 		logErr(e.what());
+		return false;
+	}
+
+	if (BoxCollider::init(this) == false) {
 		return false;
 	}
 

--- a/srcs/gui/ModelsManager.cpp
+++ b/srcs/gui/ModelsManager.cpp
@@ -66,6 +66,9 @@ bool	ModelsManager::_init(Camera const &cam) {
 
 			_models["flyingBot"] = new OpenGLModel(cam, "bomberman-assets/3dModels/"
 				"flyingBot/Original/flyingBot.fbx");
+
+			_models["terrain"] = new OpenGLModel(cam, "bomberman-assets/3dModels/"
+				"terrain/terrain.fbx");
 		}
 		catch(OpenGLModel::ModelException const & e) {
 			logErr(e.what());

--- a/srcs/scenes/SceneCheatCode.cpp
+++ b/srcs/scenes/SceneCheatCode.cpp
@@ -76,8 +76,8 @@ SceneCheatCode::SceneCheatCode(Gui * gui, float const &dtTime)
 		}},
 		{"debug", {
 			"<type> <element ...> ['list']",
-			"Show or hide debug elements.\n"
-				CHEATCODE_TAB"type: 'show' or 'hide'\n"
+			"Show, hide or reset debug elements.\n"
+				CHEATCODE_TAB"type: show, hide, reset\n"
 				CHEATCODE_TAB"/debug show collider",
 			&SceneCheatCode::_execDebug,
 		}},

--- a/srcs/scenes/SceneCheatCode.cpp
+++ b/srcs/scenes/SceneCheatCode.cpp
@@ -74,6 +74,13 @@ SceneCheatCode::SceneCheatCode(Gui * gui, float const &dtTime)
 			"Restart the level",
 			&SceneCheatCode::_execRestart,
 		}},
+		{"debug", {
+			"<type> <element ...> ['list']",
+			"Show or hide debug elements.\n"
+				CHEATCODE_TAB"type: 'show' or 'hide'\n"
+				CHEATCODE_TAB"/debug show collider",
+			&SceneCheatCode::_execDebug,
+		}},
 	};
 }
 

--- a/srcs/scenes/SceneCheatCode.cpp
+++ b/srcs/scenes/SceneCheatCode.cpp
@@ -234,6 +234,9 @@ void SceneCheatCode::load() {
 void SceneCheatCode::unload() {
 	ASceneMenu::unload();
 	_commandLine->setFocus(false);
+	if (SceneManager::getSceneName() == SceneNames::GAME) {
+		_gui->enableCursor(false);
+	}
 }
 
 /**

--- a/srcs/scenes/SceneCheatCode.cpp
+++ b/srcs/scenes/SceneCheatCode.cpp
@@ -759,6 +759,17 @@ bool SceneCheatCode::_isLevelUnlocked(uint32_t levelId) const {
 }
 
 /**
+ * @brief Public method to unlock a level
+ *
+ * @param levelId level to unlock
+ * @return int CheatcodeAction
+ */
+int	SceneCheatCode::unlockLevel(uint32_t levelId) {
+	std::vector<std::string> args = {"unlock", std::to_string(levelId)};
+	return _execUnlock(args);
+}
+
+/**
  * Logging
  */
 

--- a/srcs/scenes/SceneCheatCode_exec.cpp
+++ b/srcs/scenes/SceneCheatCode_exec.cpp
@@ -464,7 +464,7 @@ int SceneCheatCode::_execDebug(std::vector<std::string> const & args) {
 	std::map<std::string, JsonObj<bool> *> &	debugMap = debugJson.boolMap;
 
 	if (args.size() >= 3) {
-		bool value;
+		bool value = false;
 		bool reset = false;
 		if (args[1] == "show") {
 			value = true;

--- a/srcs/scenes/SceneCheatCode_exec.cpp
+++ b/srcs/scenes/SceneCheatCode_exec.cpp
@@ -4,6 +4,7 @@
 #include "Bonus.hpp"
 #include "Save.hpp"
 #include "SceneLevelSelection.hpp"
+#include "EnemyFly.hpp"
 
 int SceneCheatCode::_execHelp(std::vector<std::string> const & args) {
 	int success = CheatcodeAction::RESULT_SUCCESS;
@@ -311,7 +312,7 @@ int SceneCheatCode::_execSummon(std::vector<std::string> const & args) {
 			summonPos.y += scGame.player->getIntPos().y;
 
 		/* summon */
-		bool isFly = (args[1] == "enemyFly") ? 1 : 0;
+		bool isFly = (args[1] == ENEMY_FLY_STR) ? 1 : 0;
 		if (scGame.player != nullptr && scGame.insertEntity(args[1], summonPos, isFly)) {
 			_addLine("summon " + args[1] + " at " + std::to_string(summonPos.x) + " " + std::to_string(summonPos.y));
 		}

--- a/srcs/scenes/SceneCheatCode_exec.cpp
+++ b/srcs/scenes/SceneCheatCode_exec.cpp
@@ -455,3 +455,69 @@ int SceneCheatCode::_execRestart(std::vector<std::string> const & args) {
 	}
 	return CheatcodeAction::CLOSE | CheatcodeAction::TXT_RESET | CheatcodeAction::CHEAT_TXT_ONLY | success;
 }
+
+int SceneCheatCode::_execDebug(std::vector<std::string> const & args) {
+	int success = CheatcodeAction::RESULT_SUCCESS;
+	bool oneSuccess = false;
+
+	SettingsJson &								debugJson = s.j("debug").j("show");
+	std::map<std::string, JsonObj<bool> *> &	debugMap = debugJson.boolMap;
+
+	if (args.size() >= 3) {
+		bool value;
+		if (args[1] == "show") {
+			value = true;
+		}
+		else if (args[1] == "hide") {
+			value = false;
+		}
+		else {
+			this->logerr("Invalid debug type.\n" CHEATCODE_TAB "show, hide", false, true);
+			return CheatcodeAction::KEEP_OPEN | CheatcodeAction::TXT_KEEP | CheatcodeAction::RESULT_ERROR;
+		}
+
+		for (auto arg = args.begin() + 2; arg != args.end(); arg++) {
+			if (*arg == "list") {
+				std::string names = CHEATCODE_TAB;
+				for (auto && elem : debugMap) {
+					if (names != CHEATCODE_TAB)
+						names += ", ";
+					names += elem.first;
+				}
+				_addLine("Debug elements list:\n" + names);
+				continue;
+			}
+			try {
+				debugJson.b(*arg) = value;
+				_addLine(std::string(value ? "Show" : "Hide") + " " + *arg);
+				oneSuccess = true;
+			}
+			catch (SettingsJson::SettingsException const & e) {
+				std::string names = CHEATCODE_TAB;
+				for (auto && elem : debugMap) {
+					if (names != CHEATCODE_TAB)
+						names += ", ";
+					names += elem.first;
+				}
+				this->logerr("Invalid debug element name.\n" CHEATCODE_TAB + names, false, true);
+			}
+		}
+	}
+	else if (args.size() == 2 && args[1] == "list") {
+		std::string names = CHEATCODE_TAB;
+		for (auto && elem : debugMap) {
+			if (names != CHEATCODE_TAB)
+				names += ", ";
+			names += elem.first;
+		}
+		_addLine("Debug elements list:\n" + names);
+	}
+	else {
+		_execHelp({"help", args[0]});
+		return CheatcodeAction::KEEP_OPEN | CheatcodeAction::TXT_KEEP | CheatcodeAction::RESULT_ERROR;
+	}
+	if (oneSuccess == false) {
+		return CheatcodeAction::KEEP_OPEN | CheatcodeAction::TXT_KEEP | CheatcodeAction::RESULT_ERROR;
+	}
+	return CheatcodeAction::CLOSE | CheatcodeAction::TXT_RESET | CheatcodeAction::CHEAT_TXT_ONLY | success;
+}

--- a/srcs/scenes/SceneDebug.cpp
+++ b/srcs/scenes/SceneDebug.cpp
@@ -1,0 +1,94 @@
+#include "SceneDebug.hpp"
+
+#include <iostream>
+#include <string>
+
+
+SceneDebug::SceneDebug(Gui * gui, float const &dtTime)
+: ASceneMenu(gui, dtTime)
+{
+	_draw3dMenu = false;
+	_lastUpdateMs = getMs();
+	_fps = SceneManager::getFps();
+}
+
+SceneDebug::~SceneDebug() {
+}
+
+SceneDebug::SceneDebug(SceneDebug const &src)
+: ASceneMenu(src) {
+	*this = src;
+}
+
+SceneDebug &SceneDebug::operator=(SceneDebug const &rhs) {
+	if (this != &rhs) {
+		logWarn("you are copying SceneDebug")
+	}
+
+	return *this;
+}
+
+/**
+ * @brief init the menu
+ *
+ * @return true if the init succeed
+ * @return false if the init failed
+ */
+bool SceneDebug::init() {
+	/* create UI */
+	glm::vec2 winSz = _gui->gameInfo.windowSize;
+	glm::vec2 tmpPos;
+	glm::vec2 tmpSize;
+
+	try {
+		uint32_t	fontH = ABaseUI::strHeight(DEBUG_FONT, DEBUG_FONT_SCALE) * 1.6;
+		tmpPos.x = 3;
+		tmpPos.y = winSz.y - 4 - fontH;
+		tmpSize.x = winSz.x - (tmpPos.x * 2);
+		tmpSize.y = fontH;
+
+		_fpsText = &addText(tmpPos, tmpSize, "");
+		_fpsText->setTextFont(DEBUG_FONT)
+			.setTextScale(DEBUG_FONT_SCALE)
+			.setTextColor(DEBUG_TEXT_COLOR)
+			.setText(std::to_string(_fps) + "fps")
+			.setTextAlign(TextAlign::LEFT)
+			.setZ(1);
+
+		setVisible(false);
+	}
+	catch (ABaseUI::UIException const & e) {
+		logErr(e.what());
+		return false;
+	}
+	return true;
+}
+
+/**
+ * @brief this is the update function (called every frames)
+ *
+ * @return true if the update is a success
+ * @return false if we need to quit the command line
+ */
+bool SceneDebug::update() {
+	ASceneMenu::update();
+
+	// toggle menu visibility
+	if (Inputs::getKeyByScancodeDown(SDL_SCANCODE_F3))
+		setVisible(!_visible);
+
+	// update debug data
+	if (_visible && getMs().count() - _lastUpdateMs.count() > UPDATE_DEBUG_DATA_MS) {
+		_lastUpdateMs = getMs();
+		_fps = SceneManager::getFps();
+		_fpsText->setText(std::to_string(_fps) + "fps");
+	}
+
+	return true;
+}
+
+// -- Setters ------------------------------------------------------------------
+void	SceneDebug::setVisible(bool visible) {
+	_visible = visible;
+	_fpsText->setEnabled(_visible);
+}

--- a/srcs/scenes/SceneEndGame.cpp
+++ b/srcs/scenes/SceneEndGame.cpp
@@ -52,7 +52,11 @@ bool			SceneEndGame::init() {
 		allUI.exit = &addButton(VOID_SIZE, VOID_SIZE, "exit")
 			.setKeyLeftClickInput(InputType::CANCEL)
 			.addButtonLeftListener(&_states.exit);
-		allUI.border = &addRect(VOID_SIZE, VOID_SIZE);
+		allUI.border = &addRect(VOID_SIZE, VOID_SIZE)
+			.setTextAlign(TextAlign::CENTER);
+
+		allUI.text = &addText(VOID_SIZE, VOID_SIZE, "Ernest  Marin    Emilien  Baudet    Tim  Nicolas    Guilhem  Smith");
+		allUI.text->setPos({winSz.x / 2 - allUI.text->getSize().x / 2, 30});
 
 		_initBG();
 	}

--- a/srcs/scenes/SceneEndGame.cpp
+++ b/srcs/scenes/SceneEndGame.cpp
@@ -54,12 +54,12 @@ bool			SceneEndGame::init() {
 		addTitle(tmpPos, tmpSize, "Bomberman");
 
 		tmpPos.x = winSz.x / 2 - menuWidth / 2;
-		tmpPos.y -= menuHeight;
-		addText(tmpPos, {menuWidth, menuHeight}, "Thank's you for playing")
+		tmpPos.y -= menuHeight * 1.3;
+		addText(tmpPos, {menuWidth, menuHeight}, "Thank's you for playing !")
 			.setTextAlign(TextAlign::CENTER);
 
 		tmpPos.x = winSz.x / 2 - menuWidth / 2;
-		tmpPos.y -= menuHeight;
+		tmpPos.y -= menuHeight * 1.3;
 		addText(tmpPos, {menuWidth, menuHeight}, "Ernest  Marin")
 			.setTextAlign(TextAlign::CENTER);
 

--- a/srcs/scenes/SceneEndGame.cpp
+++ b/srcs/scenes/SceneEndGame.cpp
@@ -51,7 +51,8 @@ bool			SceneEndGame::init() {
 		tmpPos.y = winSz.y - menuHeight * 2;
 		tmpSize.x = menuWidth;
 		tmpSize.y = menuHeight;
-		addTitle(tmpPos, tmpSize, "Bomberman");
+		addTitle(tmpPos, tmpSize, "Bomberman")
+			.setTextColor(colorise(s.j("colors").j("green").u("color"), s.j("colors").j("green").u("alpha")));
 
 		tmpPos.x = winSz.x / 2 - menuWidth / 2;
 		tmpPos.y -= menuHeight * 1.3;
@@ -61,21 +62,25 @@ bool			SceneEndGame::init() {
 		tmpPos.x = winSz.x / 2 - menuWidth / 2;
 		tmpPos.y -= menuHeight * 1.3;
 		addText(tmpPos, {menuWidth, menuHeight}, "Ernest  Marin")
+			.setTextColor(colorise(s.j("colors").j("orange").u("color"), s.j("colors").j("orange").u("alpha")))
 			.setTextAlign(TextAlign::CENTER);
 
 		tmpPos.x = winSz.x / 2 - menuWidth / 2;
 		tmpPos.y -= menuHeight;
 		addText(tmpPos, {menuWidth, menuHeight}, "Emilien  Baudet")
+			.setTextColor(colorise(s.j("colors").j("orange").u("color"), s.j("colors").j("orange").u("alpha")))
 			.setTextAlign(TextAlign::CENTER);
 
 		tmpPos.x = winSz.x / 2 - menuWidth / 2;
 		tmpPos.y -= menuHeight;
 		addText(tmpPos, {menuWidth, menuHeight}, "Tim  Nicolas")
+			.setTextColor(colorise(s.j("colors").j("orange").u("color"), s.j("colors").j("orange").u("alpha")))
 			.setTextAlign(TextAlign::CENTER);
 
 		tmpPos.x = winSz.x / 2 - menuWidth / 2;
 		tmpPos.y -= menuHeight;
 		addText(tmpPos, {menuWidth, menuHeight}, "Guilhem  Smith")
+			.setTextColor(colorise(s.j("colors").j("orange").u("color"), s.j("colors").j("orange").u("alpha")))
 			.setTextAlign(TextAlign::CENTER);
 
 		_initBG();

--- a/srcs/scenes/SceneEndGame.cpp
+++ b/srcs/scenes/SceneEndGame.cpp
@@ -1,0 +1,159 @@
+#include "SceneEndGame.hpp"
+#include "Save.hpp"
+
+SceneEndGame::SceneEndGame(Gui * gui, float const &dtTime)
+: ASceneMenu(gui, dtTime)
+{
+	_draw3dMenu = false;
+}
+
+SceneEndGame::SceneEndGame(SceneEndGame const & src)
+: ASceneMenu(src)
+{
+	*this = src;
+}
+
+SceneEndGame::~SceneEndGame() {}
+
+SceneEndGame & SceneEndGame::operator=(SceneEndGame const & rhs) {
+	if (this != &rhs) {
+		logWarn("you are copying SceneEndGame")
+	}
+	return *this;
+}
+
+// - AScene Public Methods -----------------------------------------------------
+
+/**
+ * @brief init the menu
+ *
+ * @return true if the init succeed
+ * @return false if the init failed
+ */
+bool			SceneEndGame::init() {
+	glm::vec2 winSz = _gui->gameInfo.windowSize;
+	glm::vec2 tmpPos;
+	glm::vec2 tmpSize;
+	float menuWidth = winSz.x / 2;
+	float menuHeight = winSz.y / 14;
+
+	try {
+		tmpPos.x = (winSz.x / 2) - (menuWidth / 2);
+		tmpPos.y = winSz.y - menuHeight * 2;
+		tmpSize.x = menuWidth;
+		tmpSize.y = menuHeight;
+		addTitle(tmpPos, tmpSize, "You   win   !");
+
+		allUI.mainMenu = &addButton(VOID_SIZE, VOID_SIZE, "main   menu")
+			.addButtonLeftListener(&_states.mainMenu);
+		allUI.save = &addButton(VOID_SIZE, VOID_SIZE, "save")
+			.addButtonLeftListener(&_states.save);
+		allUI.exit = &addButton(VOID_SIZE, VOID_SIZE, "exit")
+			.setKeyLeftClickInput(InputType::CANCEL)
+			.addButtonLeftListener(&_states.exit);
+		allUI.border = &addRect(VOID_SIZE, VOID_SIZE);
+
+		_initBG();
+	}
+	catch (ABaseUI::UIException const & e) {
+		logErr(e.what());
+		return false;
+	}
+	return true;
+}
+
+/**
+ * @brief called when the scene is loaded
+ */
+void SceneEndGame::load() {
+	ASceneMenu::load();
+	_updateUI();
+}
+
+/**
+ * @brief this is the update function (called every frames)
+ *
+ * @return true if the update is a success
+ * @return false if there are an error in update
+ */
+bool	SceneEndGame::update() {
+	ASceneMenu::update();
+	SceneGame & scGame = *reinterpret_cast<SceneGame *>(SceneManager::getScene(SceneNames::GAME));
+	if (s.j("debug").b("3d-menu")) {
+		scGame.updateForMenu();
+	}
+
+	if (_states.mainMenu) {
+		_states.mainMenu = false;
+		SceneManager::loadScene(SceneNames::MAIN_MENU);
+	}
+	else if (_states.save) {
+		_states.save = false;
+		Save::save();
+		load();
+	}
+	else if (_states.exit) {
+		_states.exit = false;
+		SceneManager::loadScene(SceneNames::EXIT);
+	}
+	return true;
+}
+
+/**
+ * @brief this is the draw function (called every frames)
+ *
+ * @return true if the draw is a success
+ * @return false if there are an error in draw
+ */
+bool SceneEndGame::draw() {
+	bool ret = true;
+
+	/* 3d background */
+	if (s.j("debug").b("3d-menu")) {
+		SceneGame & scGame = *reinterpret_cast<SceneGame *>(SceneManager::getScene(SceneNames::GAME));
+		ret = scGame.drawEndGame();  // draw the game if possible
+	}
+	ret = ASceneMenu::draw();
+	return ret & true;
+}
+
+// -- Private methods ----------------------------------------------------------
+
+/**
+ * @brief Update UI objects.
+ *
+ */
+void		SceneEndGame::_updateUI() {
+	glm::vec2 winSz = _gui->gameInfo.windowSize;
+	glm::vec2 tmpPos;
+	glm::vec2 tmpSize;
+	float menuWidth = winSz.x / 2;
+	float menuHeight = winSz.y / 14;
+	tmpPos.x = (winSz.x / 2) - (menuWidth / 2);
+	tmpPos.y = winSz.y - menuHeight * 2;
+	tmpSize.x = menuWidth;
+	tmpSize.y = menuHeight;
+	tmpPos.y -= menuHeight * 1.8;
+	if (Save::isInstantiate()) {
+		allUI.mainMenu->setPos(tmpPos).setSize(tmpSize).setKeyLeftClickInput(InputType::CONFIRM);
+		tmpPos.y -= menuHeight * 1.3;
+		allUI.save->setPos(tmpPos).setSize(tmpSize);
+		if (Save::isSaved()) {
+			allUI.save->setText("saved").setColor(colorise(s.j("colors").j("buttons-disable").u("color")));
+		}
+		else {
+			allUI.save->setText("save ..").setColor(colorise(s.j("colors").j("buttons").u("color")));
+		}
+	}
+	else {
+		allUI.mainMenu->setPos(tmpPos).setSize(tmpSize).setKeyLeftClickInput(InputType::CONFIRM);
+		allUI.save->setPos(VOID_SIZE).setSize(VOID_SIZE);
+	}
+	tmpPos.y -= menuHeight * 1.3;
+	allUI.exit->setPos(tmpPos).setSize(tmpSize);
+	tmpSize.x = tmpSize.x * 1.3;
+	tmpSize.y = winSz.y - tmpPos.y;
+	tmpPos.x = (winSz.x / 2) - ((menuWidth * 1.3) / 2);
+	tmpPos.y -= menuHeight * 0.5;
+	allUI.border->setPos(tmpPos).setSize(tmpSize);
+}

--- a/srcs/scenes/SceneEndGame.cpp
+++ b/srcs/scenes/SceneEndGame.cpp
@@ -47,6 +47,7 @@ bool			SceneEndGame::init() {
 		allUI.mainMenu = &addButton(VOID_SIZE, VOID_SIZE, "main   menu")
 			.addButtonLeftListener(&_states.mainMenu);
 		allUI.save = &addButton(VOID_SIZE, VOID_SIZE, "save")
+			.setKeyLeftClickScancode(SDL_SCANCODE_S)
 			.addButtonLeftListener(&_states.save);
 		allUI.exit = &addButton(VOID_SIZE, VOID_SIZE, "exit")
 			.setKeyLeftClickInput(InputType::CANCEL)

--- a/srcs/scenes/SceneEndGame.cpp
+++ b/srcs/scenes/SceneEndGame.cpp
@@ -34,29 +34,49 @@ bool			SceneEndGame::init() {
 	glm::vec2 winSz = _gui->gameInfo.windowSize;
 	glm::vec2 tmpPos;
 	glm::vec2 tmpSize;
-	float menuWidth = winSz.x / 2;
+	float menuWidth = winSz.x * 0.8;
 	float menuHeight = winSz.y / 14;
 
 	try {
+		tmpSize.y = winSz.y * 0.08;
+		tmpSize.x = tmpSize.y;
+		tmpPos.x = tmpSize.x / 2;
+		tmpPos.y = winSz.y - tmpSize.y * 1.5;
+		addButton(tmpPos, tmpSize, "X")
+			.addButtonLeftListener(&_states.exit)
+			.setKeyLeftClickInput(InputType::CANCEL)
+			.setTextAlign(TextAlign::CENTER);
+
 		tmpPos.x = (winSz.x / 2) - (menuWidth / 2);
 		tmpPos.y = winSz.y - menuHeight * 2;
 		tmpSize.x = menuWidth;
 		tmpSize.y = menuHeight;
-		addTitle(tmpPos, tmpSize, "You   win   !");
+		addTitle(tmpPos, tmpSize, "Bomberman");
 
-		allUI.mainMenu = &addButton(VOID_SIZE, VOID_SIZE, "main   menu")
-			.addButtonLeftListener(&_states.mainMenu);
-		allUI.save = &addButton(VOID_SIZE, VOID_SIZE, "save")
-			.setKeyLeftClickScancode(SDL_SCANCODE_S)
-			.addButtonLeftListener(&_states.save);
-		allUI.exit = &addButton(VOID_SIZE, VOID_SIZE, "exit")
-			.setKeyLeftClickInput(InputType::CANCEL)
-			.addButtonLeftListener(&_states.exit);
-		allUI.border = &addRect(VOID_SIZE, VOID_SIZE)
+		tmpPos.x = winSz.x / 2 - menuWidth / 2;
+		tmpPos.y -= menuHeight;
+		addText(tmpPos, {menuWidth, menuHeight}, "Thank's you for playing")
 			.setTextAlign(TextAlign::CENTER);
 
-		allUI.text = &addText(VOID_SIZE, VOID_SIZE, "Ernest  Marin    Emilien  Baudet    Tim  Nicolas    Guilhem  Smith");
-		allUI.text->setPos({winSz.x / 2 - allUI.text->getSize().x / 2, 30});
+		tmpPos.x = winSz.x / 2 - menuWidth / 2;
+		tmpPos.y -= menuHeight;
+		addText(tmpPos, {menuWidth, menuHeight}, "Ernest  Marin")
+			.setTextAlign(TextAlign::CENTER);
+
+		tmpPos.x = winSz.x / 2 - menuWidth / 2;
+		tmpPos.y -= menuHeight;
+		addText(tmpPos, {menuWidth, menuHeight}, "Emilien  Baudet")
+			.setTextAlign(TextAlign::CENTER);
+
+		tmpPos.x = winSz.x / 2 - menuWidth / 2;
+		tmpPos.y -= menuHeight;
+		addText(tmpPos, {menuWidth, menuHeight}, "Tim  Nicolas")
+			.setTextAlign(TextAlign::CENTER);
+
+		tmpPos.x = winSz.x / 2 - menuWidth / 2;
+		tmpPos.y -= menuHeight;
+		addText(tmpPos, {menuWidth, menuHeight}, "Guilhem  Smith")
+			.setTextAlign(TextAlign::CENTER);
 
 		_initBG();
 	}
@@ -72,7 +92,6 @@ bool			SceneEndGame::init() {
  */
 void SceneEndGame::load() {
 	ASceneMenu::load();
-	_updateUI();
 }
 
 /**
@@ -88,18 +107,9 @@ bool	SceneEndGame::update() {
 		scGame.updateForMenu();
 	}
 
-	if (_states.mainMenu) {
-		_states.mainMenu = false;
-		SceneManager::loadScene(SceneNames::MAIN_MENU);
-	}
-	else if (_states.save) {
-		_states.save = false;
-		Save::save();
-		load();
-	}
-	else if (_states.exit) {
+	if (_states.exit) {
 		_states.exit = false;
-		SceneManager::loadScene(SceneNames::EXIT);
+		SceneManager::loadScene(SceneNames::MAIN_MENU);
 	}
 	return true;
 }
@@ -120,45 +130,4 @@ bool SceneEndGame::draw() {
 	}
 	ret = ASceneMenu::draw();
 	return ret & true;
-}
-
-// -- Private methods ----------------------------------------------------------
-
-/**
- * @brief Update UI objects.
- *
- */
-void		SceneEndGame::_updateUI() {
-	glm::vec2 winSz = _gui->gameInfo.windowSize;
-	glm::vec2 tmpPos;
-	glm::vec2 tmpSize;
-	float menuWidth = winSz.x / 2;
-	float menuHeight = winSz.y / 14;
-	tmpPos.x = (winSz.x / 2) - (menuWidth / 2);
-	tmpPos.y = winSz.y - menuHeight * 2;
-	tmpSize.x = menuWidth;
-	tmpSize.y = menuHeight;
-	tmpPos.y -= menuHeight * 1.8;
-	if (Save::isInstantiate()) {
-		allUI.mainMenu->setPos(tmpPos).setSize(tmpSize).setKeyLeftClickInput(InputType::CONFIRM);
-		tmpPos.y -= menuHeight * 1.3;
-		allUI.save->setPos(tmpPos).setSize(tmpSize);
-		if (Save::isSaved()) {
-			allUI.save->setText("saved").setColor(colorise(s.j("colors").j("buttons-disable").u("color")));
-		}
-		else {
-			allUI.save->setText("save ..").setColor(colorise(s.j("colors").j("buttons").u("color")));
-		}
-	}
-	else {
-		allUI.mainMenu->setPos(tmpPos).setSize(tmpSize).setKeyLeftClickInput(InputType::CONFIRM);
-		allUI.save->setPos(VOID_SIZE).setSize(VOID_SIZE);
-	}
-	tmpPos.y -= menuHeight * 1.3;
-	allUI.exit->setPos(tmpPos).setSize(tmpSize);
-	tmpSize.x = tmpSize.x * 1.3;
-	tmpSize.y = winSz.y - tmpPos.y;
-	tmpPos.x = (winSz.x / 2) - ((menuWidth * 1.3) / 2);
-	tmpPos.y -= menuHeight * 0.5;
-	allUI.border->setPos(tmpPos).setSize(tmpSize);
 }

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -975,6 +975,11 @@ bool SceneGame::insertEntity(std::string const & name, glm::ivec2 pos, bool isFl
 					delete entity;
 					return false;
 				}
+				if (reinterpret_cast<AEnemy *>(entity)->getCollision({pos.x, 0, pos.y}).size()) {
+					// don't create if we have a other Enemy at the same place
+					delete entity;
+					return false;
+				}
 				enemies.push_back(reinterpret_cast<AEnemy *>(entity));
 				enemies.back()->setPosition({pos.x, 0, pos.y});
 				break;

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -167,20 +167,29 @@ bool			SceneGame::init() {
 	}
 
 	/* load all models for menu */
-	_menuModels.player = new Model(ModelsManager::getModel("white"), getDtTime());
+	_menuModels.player = new Model(ModelsManager::getModel("white"), getDtTime(),
+		ETransform({0, 0, 0}, PLAYER_SIZE));
 	_menuModels.player->play = true;
 	_menuModels.player->loopAnimation = true;
 	_menuModels.player->setAnimation("Armature|idle");
 
-	_menuModels.flower = new Model(ModelsManager::getModel("flower"), getDtTime());
+	_menuModels.flower = new Model(ModelsManager::getModel("flower"), getDtTime(),
+		ETransform({0, 0, 0}, ENEMY_WITH_EYE_SIZE));
 	_menuModels.flower->play = true;
 	_menuModels.flower->loopAnimation = true;
 	_menuModels.flower->setAnimation("Armature|idle");
 
-	_menuModels.robot = new Model(ModelsManager::getModel("robot"), getDtTime());
+	_menuModels.robot = new Model(ModelsManager::getModel("robot"), getDtTime(),
+		ETransform({0, 0, 0}, ENEMY_BASIC_SIZE));
 	_menuModels.robot->play = true;
 	_menuModels.robot->loopAnimation = true;
 	_menuModels.robot->setAnimation("Armature|idle");
+
+	_menuModels.fly = new Model(ModelsManager::getModel("flyingBot"), getDtTime(),
+		ETransform({0, 0, 0}, ENEMY_FLY_SIZE));
+	_menuModels.fly->play = true;
+	_menuModels.fly->loopAnimation = true;
+	_menuModels.fly->setAnimation("Armature|run");
 
 	_initGameInfos();
 
@@ -223,7 +232,7 @@ bool	SceneGame::positionInGame(glm::vec3 pos, glm::vec3 sz) {
 bool	SceneGame::updateForMenu() {
 	/* set camera position for menu */
 	_gui->cam->setMode(CamMode::STATIC);
-	_gui->cam->pos = glm::vec3(0, 1.2, 2.3);
+	_gui->cam->pos = glm::vec3(0, 1.2, 2.5);
 	_gui->cam->lookAt(glm::vec3(0, 0.7, 0));
 	return true;
 }
@@ -381,11 +390,13 @@ bool	SceneGame::draw() {
  */
 bool	SceneGame::drawForMenu() {
 	/* draw models */
+	_menuModels.player->transform.setRot(0);
 	_menuModels.player->transform.setPos({-0.9, 0, 0});
 	if (_menuModels.player->getCurrentAnimationName() != "Armature|idle")
 		_menuModels.player->setAnimation("Armature|idle");
 	_menuModels.player->draw();
 
+	_menuModels.flower->transform.setRot(0);
 	_menuModels.flower->transform.setPos({0.9, 0, 0});
 	if (_menuModels.flower->getCurrentAnimationName() != "Armature|idle")
 		_menuModels.flower->setAnimation("Armature|idle");
@@ -465,11 +476,13 @@ bool	SceneGame::drawGame() {
  */
 bool	SceneGame::drawVictory() {
 	/* draw models */
+	_menuModels.player->transform.setRot(0);
 	_menuModels.player->transform.setPos({-1, 0, 0});
 	if (_menuModels.player->getCurrentAnimationName() != "Armature|dance")
 		_menuModels.player->setAnimation("Armature|dance");
 	_menuModels.player->draw();
 
+	_menuModels.flower->transform.setRot(0);
 	_menuModels.flower->transform.setPos({1, 0, 0});
 	if (_menuModels.flower->getCurrentAnimationName() != "Armature|loose")
 		_menuModels.flower->setAnimation("Armature|loose");
@@ -489,11 +502,13 @@ bool	SceneGame::drawVictory() {
  */
 bool	SceneGame::drawGameOver() {
 	/* draw models */
+	_menuModels.player->transform.setRot(0);
 	_menuModels.player->transform.setPos({-1, 0, 0});
 	if (_menuModels.player->getCurrentAnimationName() != "Armature|loose")
 		_menuModels.player->setAnimation("Armature|loose");
 	_menuModels.player->draw();
 
+	_menuModels.flower->transform.setRot(0);
 	_menuModels.flower->transform.setPos({1, 0, 0});
 	if (_menuModels.flower->getCurrentAnimationName() != "Armature|dance")
 		_menuModels.flower->setAnimation("Armature|dance");
@@ -514,23 +529,37 @@ bool	SceneGame::drawGameOver() {
 bool	SceneGame::drawEndGame() {
 	/* draw models */
 	float tmpX = _menuModels.player->transform.getPos().x;
-	float tmpZ = _menuModels.player->transform.getPos().z;
-	if (tmpX < -3 || tmpX > 3)
+	if (tmpX < -3 || tmpX > 7)
 		tmpX = -3;
-	tmpX += 0.04;
-	tmpX += 0.01;
+	tmpX += 0.03;
 
+	_menuModels.player->animationSpeed = 0.8;
 	_menuModels.player->transform.setPos({tmpX, -1, -2});
 	_menuModels.player->transform.setRot(90);
 	if (_menuModels.player->getCurrentAnimationName() != "Armature|run")
 		_menuModels.player->setAnimation("Armature|run");
 	_menuModels.player->draw();
 
-	_menuModels.robot->transform.setPos({tmpX - 1, -1, -2});
+	tmpX -= 1.3;
+	_menuModels.robot->transform.setPos({tmpX, -1, -2});
 	_menuModels.robot->transform.setRot(90);
 	if (_menuModels.robot->getCurrentAnimationName() != "Armature|run")
 		_menuModels.robot->setAnimation("Armature|run");
 	_menuModels.robot->draw();
+
+	tmpX -= 1.3;
+	_menuModels.flower->transform.setPos({tmpX, -1, -2});
+	_menuModels.flower->transform.setRot(90);
+	if (_menuModels.flower->getCurrentAnimationName() != "Armature|run")
+		_menuModels.flower->setAnimation("Armature|run");
+	_menuModels.flower->draw();
+
+	tmpX -= 1.3;
+	_menuModels.fly->transform.setPos({tmpX, -0.2, -2});
+	_menuModels.fly->transform.setRot(90);
+	if (_menuModels.fly->getCurrentAnimationName() != "Armature|run")
+		_menuModels.fly->setAnimation("Armature|run");
+	_menuModels.fly->draw();
 
 	// draw skybox
 	glm::mat4	view = _gui->cam->getViewMatrix();

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -25,22 +25,22 @@
 
 // -- Static members initialisation --------------------------------------------
 
-std::map<std::string, SceneGame::Entity> SceneGame::_entitiesCall = {
-	{"player", {EntityType::PLAYER, [](SceneGame &game) -> AEntity* {return new Player(game);}}},
-	{"bomb", {EntityType::BOARD, [](SceneGame &game) -> AEntity* {return new Bomb(game);}}},
-	{"wall", {EntityType::BOARD, [](SceneGame &game) -> AEntity* {return new Wall(game);}}},
+std::map<std::string, SceneGame::Entity> SceneGame::entitiesCall = {
+	{PLAYER_STR, {EntityType::PLAYER, [](SceneGame &game) -> AEntity* {return new Player(game);}}},
+	{BOMB_STR, {EntityType::BOARD, [](SceneGame &game) -> AEntity* {return new Bomb(game);}}},
+	{WALL_STR, {EntityType::BOARD, [](SceneGame &game) -> AEntity* {return new Wall(game);}}},
 	{"block", {EntityType::BOARD, [](SceneGame &game) -> AEntity* {return new Wall(game, Block::BLOCK);}}},
-	{"crispy", {EntityType::BOARD, [](SceneGame &game) -> AEntity* {return new Crispy(game);}}},
-	{"flag", {EntityType::BOARD_FLAG, [](SceneGame &game) -> AEntity* {return new Flag(game);}}},
-	{"end", {EntityType::BOARD, [](SceneGame &game) -> AEntity* {return new End(game);}}},
+	{CRISPY_STR, {EntityType::BOARD, [](SceneGame &game) -> AEntity* {return new Crispy(game);}}},
+	{FLAG_STR, {EntityType::BOARD_FLAG, [](SceneGame &game) -> AEntity* {return new Flag(game);}}},
+	{END_STR, {EntityType::BOARD, [](SceneGame &game) -> AEntity* {return new End(game);}}},
 	{"safe", {EntityType::BOARD, [](SceneGame &game) -> AEntity* {(void)game; return nullptr;}}},
 	{"empty", {EntityType::BOARD, [](SceneGame &game) -> AEntity* {(void)game; return nullptr;}}},
-	{"enemyBasic", {EntityType::ENEMY, [](SceneGame &game) -> AEntity* {return new EnemyBasic(game);}}},
-	{"enemyWithEye", {EntityType::ENEMY, [](SceneGame &game) -> AEntity* {return new EnemyWithEye(game);}}},
-	{"enemyFollow", {EntityType::ENEMY, [](SceneGame &game) -> AEntity* {return new EnemyFollow(game);}}},
-	{"enemyFly", {EntityType::ENEMY, [](SceneGame &game) -> AEntity* {return new EnemyFly(game);}}},
-	{"enemyCrispy", {EntityType::ENEMY, [](SceneGame &game) -> AEntity* {return new EnemyCrispy(game);}}},
-	{"enemyFrog", {EntityType::ENEMY, [](SceneGame &game) -> AEntity* {return new EnemyFrog(game);}}},
+	{ENEMY_BASIC_STR, {EntityType::ENEMY, [](SceneGame &game) -> AEntity* {return new EnemyBasic(game);}}},
+	{ENEMY_WITH_EYE_STR, {EntityType::ENEMY, [](SceneGame &game) -> AEntity* {return new EnemyWithEye(game);}}},
+	{ENEMY_FOLLOW_STR, {EntityType::ENEMY, [](SceneGame &game) -> AEntity* {return new EnemyFollow(game);}}},
+	{ENEMY_FLY_STR, {EntityType::ENEMY, [](SceneGame &game) -> AEntity* {return new EnemyFly(game);}}},
+	{ENEMY_CRISPY_STR, {EntityType::ENEMY, [](SceneGame &game) -> AEntity* {return new EnemyCrispy(game);}}},
+	{ENEMY_FROG_STR, {EntityType::ENEMY, [](SceneGame &game) -> AEntity* {return new EnemyFrog(game);}}},
 };
 
 // -- Constructors -------------------------------------------------------------
@@ -311,6 +311,10 @@ bool	SceneGame::update() {
 	}
 	for (auto &&enemy : enemies) {
 		if (!enemy->update())
+			return false;
+	}
+	for (auto &&spawner : spawners) {
+		if (!spawner->update())
 			return false;
 	}
 	if (!player->update()) {
@@ -650,28 +654,36 @@ bool	SceneGame::_initJsonLevel(int32_t levelId) {
 	lvl->add<SettingsJson>("objects");
 		lvl->j("objects").add<std::string>("empty", " ");
 		// unique player on game.
-		lvl->j("objects").add<std::string>("player", "p");
+		lvl->j("objects").add<std::string>(PLAYER_STR, "p");
 		// destructing element dropped by the player.
-		lvl->j("objects").add<std::string>("bomb", "x");
+		lvl->j("objects").add<std::string>(BOMB_STR, "x");
 		// indestructible element outside the board
-		lvl->j("objects").add<std::string>("wall", "w");
+		lvl->j("objects").add<std::string>(WALL_STR, "w");
 		// indestructible element of the board
 		lvl->j("objects").add<std::string>("block", "b");
 		// destructable element, who can give bonuses randomly
-		lvl->j("objects").add<std::string>("crispy", "c");
+		lvl->j("objects").add<std::string>(CRISPY_STR, "c");
 		// flag to get end
-		lvl->j("objects").add<std::string>("flag", "f");
+		lvl->j("objects").add<std::string>(FLAG_STR, "f");
 		// end of level when all flag
-		lvl->j("objects").add<std::string>("end", "e");
+		lvl->j("objects").add<std::string>(END_STR, "e");
 		// no spawn zone
 		lvl->j("objects").add<std::string>("safe", "_");
 		/* enemies */
-		lvl->j("objects").add<std::string>("enemyBasic", "0");
-		lvl->j("objects").add<std::string>("enemyWithEye", "1");
-		lvl->j("objects").add<std::string>("enemyFollow", "2");
-		lvl->j("objects").add<std::string>("enemyFly", "3");
-		lvl->j("objects").add<std::string>("enemyCrispy", "4");
-		lvl->j("objects").add<std::string>("enemyFrog", "5");
+		lvl->j("objects").add<std::string>(ENEMY_BASIC_STR, "0");
+		lvl->j("objects").add<std::string>(ENEMY_WITH_EYE_STR, "1");
+		lvl->j("objects").add<std::string>(ENEMY_FOLLOW_STR, "2");
+		lvl->j("objects").add<std::string>(ENEMY_FLY_STR, "3");
+		lvl->j("objects").add<std::string>(ENEMY_CRISPY_STR, "4");
+		lvl->j("objects").add<std::string>(ENEMY_FROG_STR, "5");
+
+	SettingsJson * spawnerPattern = new SettingsJson();
+	spawnerPattern->add<std::string>("typeEnemy", "");
+	spawnerPattern->add<uint64_t>("frequency", 5);
+	spawnerPattern->add<SettingsJson>("position");
+	spawnerPattern->j("position").add<uint64_t>("x");
+	spawnerPattern->j("position").add<uint64_t>("y");
+	lvl->addList<SettingsJson>("spawner", spawnerPattern);
 
 	SettingsJson * mapPattern = new SettingsJson();
 	mapPattern->add<std::string>("0", "");
@@ -789,7 +801,7 @@ bool	SceneGame::_loadLevel(int32_t levelId) {
 		// loop through line to create the entities
 		for (uint32_t i = 0; i < size.x; i++) {
 			std::string name;
-			for (auto &&entitYCall : _entitiesCall) {
+			for (auto &&entitYCall : entitiesCall) {
 				if (line[i] == lvl.j("objects").s(entitYCall.first)[0])
 					name = entitYCall.first;
 			}
@@ -809,7 +821,7 @@ bool	SceneGame::_loadLevel(int32_t levelId) {
 			throw SceneException(("Map fly width error on line "+std::to_string(j)).c_str());
 		for (uint32_t i = 0; i < size.x; i++) {
 			std::string name;
-			for (auto &&entitYCall : _entitiesCall) {
+			for (auto &&entitYCall : entitiesCall) {
 				if (line[i] == lvl.j("objects").s(entitYCall.first)[0])
 					name = entitYCall.first;
 			}
@@ -822,6 +834,35 @@ bool	SceneGame::_loadLevel(int32_t levelId) {
 					+ std::to_string(j) + "): " + line[i]).c_str());
 			}
 		}
+	}
+
+	for (auto spawner : lvl.lj("spawner").list) {
+		std::vector<std::string> typeEnemy;
+		if (spawner->s("typeEnemy").size() == 0)
+			throw SceneException("No type enemies defined in spawner");
+		glm::uvec2 spawnerPos = {spawner->j("position").u("x"), spawner->j("position").u("y")};
+		if (spawnerPos.x >= size.x || spawnerPos.y >= size.y) {
+			throw SceneException("Wrong position for spawner");
+		}
+		bool	found = false;
+		for (auto character : spawner->s("typeEnemy")) {
+			found = false;
+			for (auto &&entityCall : entitiesCall) {
+				if (character == lvl.j("objects").s(entityCall.first)[0]) {
+					if (entityCall.second.entityType != EntityType::ENEMY)
+						throw SceneException("Spawner only for enemies.");
+					typeEnemy.push_back(entityCall.first);
+					found = true;
+				}
+			}
+			if (!found)
+				throw SceneException("Spawner only for enemies.");
+		}
+		Spawner *spawnerEntity = new Spawner(*this);
+		spawnerEntity->setFrequency(spawner->u("frequency"))
+			.setTypeEnemy(typeEnemy)
+			.setPos({spawnerPos.x, 0, spawnerPos.y});
+		spawners.push_back(spawnerEntity);
 	}
 
 	if (player == nullptr)
@@ -856,7 +897,7 @@ bool SceneGame::insertEntity(std::string const & name, glm::ivec2 pos, bool isFl
 	}
 
 	/* if invalid entity name */
-	if (_entitiesCall.find(name) == _entitiesCall.end()) {
+	if (entitiesCall.find(name) == entitiesCall.end()) {
 		logErr("invalid entity name " << name << " in SceneGame::insertEntity");
 		return false;
 	}
@@ -875,7 +916,7 @@ bool SceneGame::insertEntity(std::string const & name, glm::ivec2 pos, bool isFl
 	if (name == "empty" && !isFly)
 		entity = Crispy::generateCrispy(*this, wallGenPercent);
 	else
-		entity = _entitiesCall[name].entity(*this);
+		entity = entitiesCall[name].entity(*this);
 
 	// do nothing on empty block
 	if (entity == nullptr)
@@ -886,7 +927,7 @@ bool SceneGame::insertEntity(std::string const & name, glm::ivec2 pos, bool isFl
 			reinterpret_cast<AObject *>(entity)->isInFlyBoard = true;
 			boardFly[pos.x][pos.y].push_back(entity);
 		}
-		else if (_entitiesCall[name].entityType == EntityType::ENEMY) {
+		else if (entitiesCall[name].entityType == EntityType::ENEMY) {
 			enemies.push_back(reinterpret_cast<AEnemy *>(entity));
 			enemies.back()->setPosition({pos.x, 1, pos.y});
 		}
@@ -895,7 +936,7 @@ bool SceneGame::insertEntity(std::string const & name, glm::ivec2 pos, bool isFl
 		}
 	}
 	else {  // if not fly
-		switch (_entitiesCall[name].entityType) {
+		switch (entitiesCall[name].entityType) {
 			case EntityType::PLAYER:
 				if (player == nullptr) {
 					player = reinterpret_cast<Player *>(entity);
@@ -1209,7 +1250,7 @@ SettingsJson	&SceneGame::getSettingsLevel() const {
  */
 std::vector<std::string> SceneGame::getAllEntityNames() {
 	std::vector<std::string> res;
-	for (auto && it : _entitiesCall) {
+	for (auto && it : entitiesCall) {
 		res.push_back(it.first);
 	}
 	return res;

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -267,7 +267,12 @@ bool	SceneGame::update() {
 			}
 		}
 		score.addBonusTime(levelTime, time);
-		score.addBonusEnemies(levelEnemies, enemies.size(), levelCrispies, crispiesLast);
+		uint32_t remainEnemies = 0;
+		for (auto && it : enemies) {
+			if (it->alive)
+				remainEnemies++;
+		}
+		score.addBonusEnemies(levelEnemies, remainEnemies, levelCrispies, crispiesLast);
 		Save::updateSavedFile(*this, true);
 		Save::save(true);
 		SceneManager::loadScene(SceneNames::VICTORY);

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -746,6 +746,10 @@ bool	SceneGame::_loadLevel(int32_t levelId) {
 		return false;
 	}
 
+	// Delete old player
+	delete player;
+	player = nullptr;
+
 	level = levelId;  // save new level ID
 	SettingsJson & lvl = *(_mapsList[level]);
 

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -404,46 +404,43 @@ bool	SceneGame::drawForMenu() {
  * @return false If failed
  */
 bool	SceneGame::drawGame() {
-	if (s.j("debug").b("showBaseBoard")) {
+	if (s.j("debug").j("show").b("baseBoard")) {
 		// draw floor
 		_gui->drawCube(Block::FLOOR, {0.0f, -0.3f, 0.0f}, {size.x, 0.3f, size.y});
 	}
 
-	if (s.j("debug").b("showBaseBoard")) {
-		for (auto &&board_it0 : board) {
-			for (auto &&board_it1 : board_it0) {
-				for (AEntity *board_it2 : board_it1) {
-					if (!board_it2->draw(*_gui))
-						return false;
-					if (s.j("debug").b("showStaticCollider") && !board_it2->drawCollider())
-						return false;
-				}
+	for (auto &&board_it0 : board) {
+		for (auto &&board_it1 : board_it0) {
+			for (AEntity *board_it2 : board_it1) {
+				if (s.j("debug").j("show").b("baseBoard") && !board_it2->draw(*_gui))
+					return false;
+				if (s.j("debug").j("show").b("staticCollider") && !board_it2->drawCollider())
+					return false;
 			}
 		}
 	}
-	if (s.j("debug").b("showFlyHeight")) {
-		for (auto &&board_it0 : boardFly) {
-			for (auto &&board_it1 : board_it0) {
-				for (AEntity *board_it2 : board_it1) {
-					if (!board_it2->draw(*_gui))
-						return false;
-					if (s.j("debug").b("showStaticCollider") && !board_it2->drawCollider())
-						return false;
-				}
+
+	for (auto &&board_it0 : boardFly) {
+		for (auto &&board_it1 : board_it0) {
+			for (AEntity *board_it2 : board_it1) {
+				if (s.j("debug").j("show").b("flyHeight") && !board_it2->draw(*_gui))
+					return false;
+				if (s.j("debug").j("show").b("staticCollider") && !board_it2->drawCollider())
+					return false;
 			}
 		}
 	}
-	if (s.j("debug").b("showEntity")) {
-		for (auto &&enemy : enemies) {
-			if (!enemy->draw(*_gui))
-				return false;
-			if (s.j("debug").b("showMovingCollider") && !enemy->drawCollider())
-				return false;
-		}
-		player->draw(*_gui);
-		if (s.j("debug").b("showMovingCollider") && !player->drawCollider())
+
+	for (auto &&enemy : enemies) {
+		if (s.j("debug").j("show").b("entity") && !enemy->draw(*_gui))
+			return false;
+		if (s.j("debug").j("show").b("movingCollider") && !enemy->drawCollider())
 			return false;
 	}
+	if (s.j("debug").j("show").b("entity") && !player->draw(*_gui))
+		return false;
+	if (s.j("debug").j("show").b("movingCollider") && !player->drawCollider())
+		return false;
 
 	// release cubeShader and textures
 	_gui->cubeShader->use();

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -507,6 +507,39 @@ bool	SceneGame::drawGameOver() {
 }
 
 /**
+ * @brief Draw function if we are in endGame menu
+ *
+ * @return false If failed
+ */
+bool	SceneGame::drawEndGame() {
+	/* draw models */
+	float tmpX = _menuModels.player->transform.getPos().x;
+	float tmpZ = _menuModels.player->transform.getPos().z;
+	if (tmpX < -3 || tmpX > 3)
+		tmpX = -3;
+	tmpX += 0.04;
+	tmpX += 0.01;
+
+	_menuModels.player->transform.setPos({tmpX, -1, -2});
+	_menuModels.player->transform.setRot(90);
+	if (_menuModels.player->getCurrentAnimationName() != "Armature|run")
+		_menuModels.player->setAnimation("Armature|run");
+	_menuModels.player->draw();
+
+	_menuModels.robot->transform.setPos({tmpX - 1, -1, -2});
+	_menuModels.robot->transform.setRot(90);
+	if (_menuModels.robot->getCurrentAnimationName() != "Armature|run")
+		_menuModels.robot->setAnimation("Armature|run");
+	_menuModels.robot->draw();
+
+	// draw skybox
+	glm::mat4	view = _gui->cam->getViewMatrix();
+	_gui->drawSkybox(view);
+
+	return true;
+}
+
+/**
  * @brief called when the scene is loaded
  */
 void SceneGame::load() {

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -7,6 +7,7 @@
 #include "FileUtils.hpp"
 #include "Save.hpp"
 #include "ModelsManager.hpp"
+#include "BoxCollider.hpp"
 
 #include "Player.hpp"
 #include "Wall.hpp"
@@ -414,6 +415,8 @@ bool	SceneGame::drawGame() {
 				for (AEntity *board_it2 : board_it1) {
 					if (!board_it2->draw(*_gui))
 						return false;
+					if (s.j("debug").b("showStaticCollider") && !board_it2->drawCollider())
+						return false;
 				}
 			}
 		}
@@ -424,6 +427,8 @@ bool	SceneGame::drawGame() {
 				for (AEntity *board_it2 : board_it1) {
 					if (!board_it2->draw(*_gui))
 						return false;
+					if (s.j("debug").b("showStaticCollider") && !board_it2->drawCollider())
+						return false;
 				}
 			}
 		}
@@ -432,8 +437,12 @@ bool	SceneGame::drawGame() {
 		for (auto &&enemy : enemies) {
 			if (!enemy->draw(*_gui))
 				return false;
+			if (s.j("debug").b("showMovingCollider") && !enemy->drawCollider())
+				return false;
 		}
 		player->draw(*_gui);
+		if (s.j("debug").b("showMovingCollider") && !player->drawCollider())
+			return false;
 	}
 
 	// release cubeShader and textures

--- a/srcs/scenes/SceneLevelSelection.cpp
+++ b/srcs/scenes/SceneLevelSelection.cpp
@@ -45,6 +45,16 @@ bool			SceneLevelSelection::init() {
 
 	try {
 		_states.nbLevel = scGame.getNbLevel();
+
+		tmpSize.y = winSz.y * 0.08;
+		tmpSize.x = tmpSize.y;
+		tmpPos.x = tmpSize.x / 2;
+		tmpPos.y = winSz.y - tmpSize.y * 1.5;
+		addButton(tmpPos, tmpSize, "X")
+			.addButtonLeftListener(&_states.menu)
+			.setKeyLeftClickInput(InputType::CANCEL)
+			.setTextAlign(TextAlign::CENTER);
+
 		tmpSize.x = menuWidth;
 		tmpSize.y = menuHeight * 5;
 		tmpPos.x = (winSz.x / 2) - (tmpSize.x / 2);
@@ -161,7 +171,7 @@ bool	SceneLevelSelection::update() {
 			return true;
 		}
 	}
-	if (_states.menu || Inputs::getKeyUp(InputType::CANCEL)) {
+	if (_states.menu) {
 		_states.menu = false;
 		SceneManager::loadScene(SceneNames::MAIN_MENU);
 	}

--- a/srcs/scenes/SceneLevelSelection.cpp
+++ b/srcs/scenes/SceneLevelSelection.cpp
@@ -110,7 +110,6 @@ bool	SceneLevelSelection::update() {
 	glm::vec2 winSz = _gui->gameInfo.windowSize;
 	// SceneGame reference
 	SceneGame & scGame = *reinterpret_cast<SceneGame *>(SceneManager::getScene(SceneNames::GAME));
-	SceneCheatCode & scCheatCode = *reinterpret_cast<SceneCheatCode *>(SceneManager::getScene(SceneNames::CHEAT_CODE));
 
 	allUI.text->setText("Level " + std::to_string(_currentLvl));
 	if (Save::isLevelDone(_currentLvl)) {
@@ -147,6 +146,9 @@ bool	SceneLevelSelection::update() {
 				}
 			} catch (std::exception const &e) {
 				logErr("Error: " << e.what());
+				SceneCheatCode & scCheatCode = *reinterpret_cast<SceneCheatCode *>(
+					SceneManager::getScene(SceneNames::CHEAT_CODE)
+				);
 				scCheatCode.logerr(e.what());
 				scCheatCode.unlockLevel(_currentLvl + 1);
 				SceneManager::loadScene(SceneNames::LEVEL_SELECTION);

--- a/srcs/scenes/SceneLevelSelection.cpp
+++ b/srcs/scenes/SceneLevelSelection.cpp
@@ -149,7 +149,10 @@ bool	SceneLevelSelection::update() {
 				SceneCheatCode & scCheatCode = *reinterpret_cast<SceneCheatCode *>(
 					SceneManager::getScene(SceneNames::CHEAT_CODE)
 				);
-				scCheatCode.logerr(e.what());
+				scCheatCode.clearAllLn();
+				std::stringstream ss;
+				ss << "Level " << _currentLvl << ": " << e.what();
+				scCheatCode.logerr(ss.str());
 				scCheatCode.unlockLevel(_currentLvl + 1);
 				SceneManager::loadScene(SceneNames::LEVEL_SELECTION);
 				return true;

--- a/srcs/scenes/SceneLevelSelection.cpp
+++ b/srcs/scenes/SceneLevelSelection.cpp
@@ -111,7 +111,7 @@ bool	SceneLevelSelection::update() {
 	// SceneGame reference
 	SceneGame & scGame = *reinterpret_cast<SceneGame *>(SceneManager::getScene(SceneNames::GAME));
 
-	allUI.text->setText("Level " + std::to_string(_currentLvl));
+	allUI.text->setText(scGame.getLevelName(_currentLvl));
 	if (Save::isLevelDone(_currentLvl)) {
 		allUI.score->setText("score: " + std::to_string(Save::getLevelScore(_currentLvl)));
 	} else if (_currentLvl == 0 || Save::isLevelDone(_currentLvl - 1) || SceneCheatCode::isLevelUnlocked(_currentLvl)) {

--- a/srcs/scenes/SceneLevelSelection.cpp
+++ b/srcs/scenes/SceneLevelSelection.cpp
@@ -2,6 +2,7 @@
 #include "SceneGame.hpp"
 #include "Save.hpp"
 #include "SceneCheatCode.hpp"
+#include "SceneManager.hpp"
 
 SceneLevelSelection::SceneLevelSelection(Gui * gui, float const &dtTime)
 : ASceneMenu(gui, dtTime),
@@ -109,6 +110,7 @@ bool	SceneLevelSelection::update() {
 	glm::vec2 winSz = _gui->gameInfo.windowSize;
 	// SceneGame reference
 	SceneGame & scGame = *reinterpret_cast<SceneGame *>(SceneManager::getScene(SceneNames::GAME));
+	SceneCheatCode & scCheatCode = *reinterpret_cast<SceneCheatCode *>(SceneManager::getScene(SceneNames::CHEAT_CODE));
 
 	allUI.text->setText("Level " + std::to_string(_currentLvl));
 	if (Save::isLevelDone(_currentLvl)) {
@@ -145,7 +147,10 @@ bool	SceneLevelSelection::update() {
 				}
 			} catch (std::exception const &e) {
 				logErr("Error: " << e.what());
-				return false;
+				scCheatCode.logerr(e.what());
+				scCheatCode.unlockLevel(_currentLvl + 1);
+				SceneManager::loadScene(SceneNames::LEVEL_SELECTION);
+				return true;
 			}
 			SceneManager::loadScene(SceneNames::GAME);
 			return true;

--- a/srcs/scenes/SceneLoadGame.cpp
+++ b/srcs/scenes/SceneLoadGame.cpp
@@ -157,6 +157,7 @@ void SceneLoadGame::load() {
 			.setColor(colorise(s.j("colors").j("blue").u("color")))
 			.setBorderColor(colorise(s.j("colors").j("blue").u("color")))
 			.addButtonLeftListener(&_states.loadGame)
+			.setKeyLeftClickInput(InputType::CONFIRM)
 			.setMaster(previewGame);
 		tempPrevPos.y -= tmpSize.y * 1.3;
 		previewGameUI.deleteGame = &addButton(tempPrevPos, tempPrevSize, "delete")
@@ -164,6 +165,7 @@ void SceneLoadGame::load() {
 			.setColor(colorise(s.j("colors").j("red").u("color")))
 			.setBorderColor(colorise(s.j("colors").j("red").u("color")))
 			.addButtonLeftListener(&_states.deleteGame)
+			.setKeyLeftClickScancode(SDL_SCANCODE_DELETE)
 			.setMaster(previewGame);
 
 		tmpPos.y -= savedGamesSize.y;

--- a/srcs/scenes/SceneMainMenu.cpp
+++ b/srcs/scenes/SceneMainMenu.cpp
@@ -46,8 +46,10 @@ bool			SceneMainMenu::init() {
 		allUI.continueGame = &addButton(VOID_SIZE, VOID_SIZE, "continue")
 			.addButtonLeftListener(&_states.continueGame);
 		allUI.save = &addButton(VOID_SIZE, VOID_SIZE, "save")
+			.setKeyLeftClickScancode(SDL_SCANCODE_S)
 			.addButtonLeftListener(&_states.save);
 		allUI.newGame = &addButton(VOID_SIZE, VOID_SIZE, "new   game")
+			.setKeyLeftClickScancode(SDL_SCANCODE_N)
 			.addButtonLeftListener(&_states.newGame);
 		allUI.loadGame = &addButton(VOID_SIZE, VOID_SIZE, "load   saved   game")
 			.setKeyLeftClickInput(InputType::ACTION)

--- a/srcs/scenes/SceneManager.cpp
+++ b/srcs/scenes/SceneManager.cpp
@@ -17,12 +17,13 @@
 #include "SceneSettings.hpp"
 #include "SceneLoadGame.hpp"
 #include "SceneCheatCode.hpp"
+#include "SceneEndGame.hpp"
 
 SceneManager::SceneManager()
 : _gameInfo(),
   _gui(nullptr),
   _dtTime(0.0f),
-  _scene(SceneNames::MAIN_MENU),
+  _scene(SceneNames::END_GAME),
   _isInCheatCode(false),
   _showCheatCodeTextTime(0),
   _sceneLoadedCurrentFrame(false)
@@ -104,6 +105,7 @@ bool SceneManager::_init() {
 	_sceneMap.insert(std::pair<std::string, AScene *>(SceneNames::SETTINGS, new SceneSettings(_gui, _dtTime)));
 	_sceneMap.insert(std::pair<std::string, AScene *>(SceneNames::LOADGAME, new SceneLoadGame(_gui, _dtTime)));
 	_sceneMap.insert(std::pair<std::string, AScene *>(SceneNames::CHEAT_CODE, new SceneCheatCode(_gui, _dtTime)));
+	_sceneMap.insert(std::pair<std::string, AScene *>(SceneNames::END_GAME, new SceneEndGame(_gui, _dtTime)));
 
 	for (auto it = _sceneMap.begin(); it != _sceneMap.end(); it++) {
 		try {

--- a/srcs/scenes/SceneManager.cpp
+++ b/srcs/scenes/SceneManager.cpp
@@ -25,6 +25,7 @@ SceneManager::SceneManager()
   _scene(SceneNames::MAIN_MENU),
   _isInCheatCode(false),
   _showCheatCodeTextTime(0),
+  _fps(60),
   _sceneLoadedCurrentFrame(false)
 {}
 
@@ -124,10 +125,12 @@ bool SceneManager::_init() {
  * @return false if failure
  */
 bool SceneManager::run() {
-	return SceneManager::get()._run();
+	float		maxFrameDuration = 1000 / s.j("screen").u("fps");
+
+	return SceneManager::get()._run(maxFrameDuration);
 }
-bool SceneManager::_run() {
-	float						fps = 1000 / s.j("screen").u("fps");
+
+bool SceneManager::_run(float maxFrameDuration) {
 	std::chrono::milliseconds	lastLoopMs = getMs();
 
 	while (true) {
@@ -155,14 +158,19 @@ bool SceneManager::_run() {
 
 		/* fps control */
 		std::chrono::milliseconds loopDuration = getMs() - lastLoopMs;
-		if (loopDuration.count() > fps) {
+		float	frameDuration = loopDuration.count();
+		_fps = 1000 / frameDuration;
+
+		if (frameDuration > maxFrameDuration) {
 			#if DEBUG_FPS_LOW == true
-				if (!firstLoop)
-					logDebug("update loop slow -> " << loopDuration.count() << "ms / " << fps << "ms (" << FPS << "fps)");
+				if (!firstLoop) {
+					logDebug("update loop slow -> " << frameDuration << "ms / " <<
+					maxFrameDuration << "ms (" << s.j("screen").u("fps") << "fps)");
+				}
 			#endif
 		}
 		else {
-			usleep((fps - loopDuration.count()) * 1000);
+			usleep((maxFrameDuration - frameDuration) * 1000);
 		}
 		#if DEBUG_FPS_LOW == true
 			firstLoop = false;
@@ -297,6 +305,15 @@ std::string const & SceneManager::getSceneName() {
 }
 std::string const & SceneManager::_getSceneName() const {
 	return _scene;
+}
+
+/**
+ * @brief get the current fps count
+ *
+ * @return uint16_t the current fps count
+ */
+uint16_t	SceneManager::getFps() {
+	return SceneManager::get()._fps;
 }
 
 /**

--- a/srcs/scenes/SceneManager.cpp
+++ b/srcs/scenes/SceneManager.cpp
@@ -23,7 +23,7 @@ SceneManager::SceneManager()
 : _gameInfo(),
   _gui(nullptr),
   _dtTime(0.0f),
-  _scene(SceneNames::END_GAME),
+  _scene(SceneNames::MAIN_MENU),
   _isInCheatCode(false),
   _showCheatCodeTextTime(0),
   _sceneLoadedCurrentFrame(false)

--- a/srcs/scenes/ScenePause.cpp
+++ b/srcs/scenes/ScenePause.cpp
@@ -50,6 +50,7 @@ bool			ScenePause::init() {
 
 		tmpPos.y -= menuHeight * 1.3;
 		addButton(tmpPos, tmpSize, "restart")
+			.setKeyLeftClickScancode(SDL_SCANCODE_R)
 			.addButtonLeftListener(&_states.restart);
 
 		tmpPos.y -= menuHeight * 1.3;

--- a/srcs/scenes/SceneSettings.cpp
+++ b/srcs/scenes/SceneSettings.cpp
@@ -121,10 +121,10 @@ bool					SceneSettings::init() {
 	_current_resolution = SceneSettings::resolutions[_select_res];
 
 	try {
-		tmp_size.y = menu_height * 0.1;
+		tmp_size.y = win_size.y * 0.08;
 		tmp_size.x = tmp_size.y;
-		tmp_pos.x = (win_size.x / 2) - (menu_width / 2);
-		tmp_pos.y = win_size.y - (win_size.y - menu_height) / 2 - tmp_size.y;
+		tmp_pos.x = tmp_size.x / 2;
+		tmp_pos.y = win_size.y - tmp_size.y * 1.5;
 		addButton(tmp_pos, tmp_size, "X")
 			.addButtonLeftListener(&_return)
 			.setKeyLeftClickInput(InputType::CANCEL)
@@ -132,6 +132,7 @@ bool					SceneSettings::init() {
 			.setTextAlign(TextAlign::CENTER);
 		tmp_size.x = menu_width;
 		tmp_size.y = menu_height * 0.2;
+		tmp_pos.x = (win_size.x / 2) - (menu_width / 2);
 		tmp_pos.y = win_size.y - (win_size.y - menu_height) / 2 - tmp_size.y;
 		addTitle(tmp_pos, tmp_size, "Settings");
 		tmp_size.y = menu_height * 0.1;

--- a/srcs/scenes/SceneSettings.cpp
+++ b/srcs/scenes/SceneSettings.cpp
@@ -339,16 +339,6 @@ void					SceneSettings::_init_control_pane(glm::vec2 tmp_pos, float menu_width, 
 		_panes[SettingsType::CONTROLS].push_front(ptr);
 		_key_buttons[i] = reinterpret_cast<ButtonUI*>(ptr);
 	}
-	tmp_size.y = menu_height * 0.1;
-	tmp_size.x = menu_width * 0.15;
-	tmp_pos.x = (win_size.x / 2) + (menu_width / 2) - menu_width * 0.1;
-	tmp_pos.y = win_size.y - (win_size.y - menu_height) / 2 - tmp_size.y;
-	ptr = &addButton(tmp_pos, tmp_size, "Reset")
-		.addButtonLeftListener(&_reset)
-		.setTextScale(_text_scale)
-		.setTextAlign(TextAlign::CENTER)
-		.setEnabled(false);
-	_panes[SettingsType::CONTROLS].push_front(ptr);
 	// add mouse sensitivity slider
 	tmp_pos.y -= keyMenuHeight + keyMenuPadding;
 	tmp_pos.x = 0;
@@ -364,6 +354,17 @@ void					SceneSettings::_init_control_pane(glm::vec2 tmp_pos, float menu_width, 
 		.addButtonLeftListener(&_save_mouse_sens)
 		.setTextScale(_text_scale)
 		.setMaster(scrollbar)
+		.setEnabled(false);
+	_panes[SettingsType::CONTROLS].push_front(ptr);
+	// reset
+	tmp_size.y = menu_height * 0.1;
+	tmp_size.x = menu_width * 0.15;
+	tmp_pos.x = (win_size.x / 2) + (menu_width / 2) - menu_width * 0.1;
+	tmp_pos.y = win_size.y - (win_size.y - menu_height) / 2 - tmp_size.y;
+	ptr = &addButton(tmp_pos, tmp_size, "Reset")
+		.addButtonLeftListener(&_reset)
+		.setTextScale(_text_scale)
+		.setTextAlign(TextAlign::CENTER)
 		.setEnabled(false);
 	_panes[SettingsType::CONTROLS].push_front(ptr);
 }

--- a/srcs/scenes/SceneVictory.cpp
+++ b/srcs/scenes/SceneVictory.cpp
@@ -160,7 +160,10 @@ bool	SceneVictory::update() {
 					SceneManager::getScene(SceneNames::CHEAT_CODE)
 				);
 				logErr("Error: " << e.what());
-				scCheatCode.logerr(e.what());
+				scCheatCode.clearAllLn();
+				std::stringstream ss;
+				ss << "Level " << scGame.level << ": " << e.what();
+				scCheatCode.logerr(ss.str());
 				scCheatCode.unlockLevel(scGame.level + 1);
 				SceneManager::loadScene(SceneNames::LEVEL_SELECTION);
 				return true;

--- a/srcs/scenes/SceneVictory.cpp
+++ b/srcs/scenes/SceneVictory.cpp
@@ -1,5 +1,6 @@
 #include "SceneVictory.hpp"
 #include "SceneGame.hpp"
+#include "SceneCheatCode.hpp"
 
 SceneVictory::SceneVictory(Gui * gui, float const &dtTime)
 : ASceneMenu(gui, dtTime),
@@ -155,8 +156,14 @@ bool	SceneVictory::update() {
 					return false;
 				}
 			} catch (std::exception const &e) {
+				SceneCheatCode & scCheatCode = *reinterpret_cast<SceneCheatCode *>(
+					SceneManager::getScene(SceneNames::CHEAT_CODE)
+				);
 				logErr("Error: " << e.what());
-				return false;
+				scCheatCode.logerr(e.what());
+				scCheatCode.unlockLevel(scGame.level + 1);
+				SceneManager::loadScene(SceneNames::LEVEL_SELECTION);
+				return true;
 			}
 			SceneManager::loadScene(_lastSceneName);
 		}

--- a/srcs/scenes/SceneVictory.cpp
+++ b/srcs/scenes/SceneVictory.cpp
@@ -171,7 +171,7 @@ bool	SceneVictory::update() {
 			SceneManager::loadScene(_lastSceneName);
 		}
 		else {
-			SceneManager::loadScene(SceneNames::MAIN_MENU);
+			SceneManager::loadScene(SceneNames::END_GAME);
 		}
 	}
 	else if (_states.restart) {

--- a/srcs/utils/opengl/Camera.cpp
+++ b/srcs/utils/opengl/Camera.cpp
@@ -30,6 +30,8 @@ Camera::Camera(float const ratio, CAMERA_VEC3 pos, CAMERA_VEC3 up, CAMERA_FLOAT 
 	_updateProjection();
 
 	_updateCameraVectors();
+
+	frustumCullingInit(_fovY, _ratio, _near, _far);
 }
 
 Camera::~Camera() {
@@ -37,6 +39,7 @@ Camera::~Camera() {
 
 Camera::Camera(Camera const &src) {
 	*this = src;
+	frustumCullingInit(_fovY, _ratio, _near, _far);
 }
 
 Camera	&Camera::operator=(Camera const &rhs) {

--- a/srcs/utils/opengl/Camera.cpp
+++ b/srcs/utils/opengl/Camera.cpp
@@ -386,7 +386,7 @@ void	Camera::frustumCullingInit(CAMERA_FLOAT angleDeg, CAMERA_FLOAT ratio,
  * @param point The 3D point
  * @return int The point position (FRCL_INSIDE == is inside)
  */
-int		Camera::frustumCullingCheckPoint(CAMERA_VEC3 const &point) {
+int		Camera::frustumCullingCheckPoint(CAMERA_VEC3 const &point) const {
 	CAMERA_FLOAT	pcz, pcx, pcy, aux;
 	int		res = FRCL_INSIDE;
 
@@ -432,7 +432,7 @@ int		Camera::frustumCullingCheckPoint(CAMERA_VEC3 const &point) {
  * @param size The scale in X Y and Z of the cube
  * @return int The point position (FRCL_INSIDE == is inside)
  */
-int		Camera::frustumCullingCheckCube(CAMERA_VEC3 const &startPoint, CAMERA_VEC3 &size) {
+int		Camera::frustumCullingCheckCube(CAMERA_VEC3 const &startPoint, CAMERA_VEC3 const &size) const {
 	int			res;  // point1 & point2 & point3 ...
 	int			tmpRes;
 	CAMERA_VEC3	pos;

--- a/srcs/utils/opengl/Camera.cpp
+++ b/srcs/utils/opengl/Camera.cpp
@@ -117,8 +117,7 @@ void	Camera::setMode(CamMode::Enum mode) {
 		return;
 	_mode = mode;
 	if (_mode == CamMode::FOLLOW_PATH) {
-		_followIsFinished = false;
-		_followCurElem = -1;
+		resetFollowPath();
 	}
 }
 
@@ -494,7 +493,14 @@ int		Camera::frustumCullingCheckCube(CAMERA_VEC3 const &startPoint, CAMERA_VEC3 
 }
 
 // -- follow path --------------------------------------------------------------
-void	Camera::setFollowPath(std::vector<CamPoint> const & path) { _followPath = path; }
+void	Camera::resetFollowPath() {
+	_followIsFinished = false;
+	_followCurElem = -1;
+}
+void	Camera::setFollowPath(std::vector<CamPoint> const & path) {
+	resetFollowPath();
+	_followPath = path;
+}
 void	Camera::setFollowRepeat(bool repeat) { _followIsRepeat = repeat; }
 bool	Camera::isFollowFinished() const { return _followIsFinished; }
 bool	Camera::isFollowRepeat() const { return _followIsRepeat; }

--- a/srcs/utils/opengl/Inputs.cpp
+++ b/srcs/utils/opengl/Inputs.cpp
@@ -511,8 +511,8 @@ void				Inputs::_update() {
 					_input_key_map[scan] = _next_action_type;
 					_controls.saveToFile(Inputs::configFile);
 					_configuring = false;
-					_key_status[static_cast<int>(_next_action_type)] = true;
-					_key_previous_status[_next_action_type] = true;
+					// _key_status[static_cast<int>(_next_action_type)] = true;
+					// _key_previous_status[_next_action_type] = true;
 					logInfo("Input '" << input_type_name[_next_action_type] << "' set.")
 				}
 				else {
@@ -553,7 +553,7 @@ void				Inputs::_update() {
                         break;
                 }
                 break;
-		 case SDL_MOUSEBUTTONUP:
+		case SDL_MOUSEBUTTONUP:
                 switch (event.button.button) {
                     case SDL_BUTTON_LEFT:
 						_left_click = false;


### PR DESCRIPTION
✅ close #145 enemies counter bug
✅ close #153 add box collider preview
✅ close #147 Make enemies center themself instead of walking allong walls 
✅ close #157 bug when setting cheatcode key 
✅ close #150 Simple end screen when all levels are finished
✅ close #163 restart should start camera anim to start or skip it

## ajout
### nouvelle commande -> /debug
```
/debug <type> <element ...> ['list']  # permet de montrer ou cacher des elements:
/debug show movingCollider  # permet de voir le collider des elements qui bougent
/debug reset entity  # permet de remettre la valeur par default pour les entités
```
cette commande peut changer la valeur de tout les `bool` dans `s.j("debug").j("show")`