### PR TITLE
Feature/error message

### DIFF
--- a/includes/scenes/SceneCheatCode.hpp
+++ b/includes/scenes/SceneCheatCode.hpp
@@ -79,6 +79,7 @@ class SceneCheatCode : public ASceneMenu {
 		void				setText(std::string const & txt);
 		std::string			getText() const;
 		static bool			isLevelUnlocked(uint32_t levelId);
+		int					unlockLevel(uint32_t levelId);
 
 		/* log */
 		void				logdebug(std::string const & msg, bool clear = false, bool logOnly = false);

--- a/srcs/scenes/SceneCheatCode.cpp
+++ b/srcs/scenes/SceneCheatCode.cpp
@@ -759,6 +759,17 @@ bool SceneCheatCode::_isLevelUnlocked(uint32_t levelId) const {
 }
 
 /**
+ * @brief Public method to unlock a level
+ *
+ * @param levelId level to unlock
+ * @return int CheatcodeAction
+ */
+int	SceneCheatCode::unlockLevel(uint32_t levelId) {
+	std::vector<std::string> args = {"unlock", std::to_string(levelId)};
+	return _execUnlock(args);
+}
+
+/**
  * Logging
  */
 

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -746,6 +746,10 @@ bool	SceneGame::_loadLevel(int32_t levelId) {
 		return false;
 	}
 
+	// Delete old player
+	delete player;
+	player = nullptr;
+
 	level = levelId;  // save new level ID
 	SettingsJson & lvl = *(_mapsList[level]);
 

--- a/srcs/scenes/SceneLevelSelection.cpp
+++ b/srcs/scenes/SceneLevelSelection.cpp
@@ -110,7 +110,6 @@ bool	SceneLevelSelection::update() {
 	glm::vec2 winSz = _gui->gameInfo.windowSize;
 	// SceneGame reference
 	SceneGame & scGame = *reinterpret_cast<SceneGame *>(SceneManager::getScene(SceneNames::GAME));
-	SceneCheatCode & scCheatCode = *reinterpret_cast<SceneCheatCode *>(SceneManager::getScene(SceneNames::CHEAT_CODE));
 
 	allUI.text->setText("Level " + std::to_string(_currentLvl));
 	if (Save::isLevelDone(_currentLvl)) {
@@ -147,6 +146,9 @@ bool	SceneLevelSelection::update() {
 				}
 			} catch (std::exception const &e) {
 				logErr("Error: " << e.what());
+				SceneCheatCode & scCheatCode = *reinterpret_cast<SceneCheatCode *>(
+					SceneManager::getScene(SceneNames::CHEAT_CODE)
+				);
 				scCheatCode.logerr(e.what());
 				scCheatCode.unlockLevel(_currentLvl + 1);
 				SceneManager::loadScene(SceneNames::LEVEL_SELECTION);

--- a/srcs/scenes/SceneLevelSelection.cpp
+++ b/srcs/scenes/SceneLevelSelection.cpp
@@ -149,7 +149,10 @@ bool	SceneLevelSelection::update() {
 				SceneCheatCode & scCheatCode = *reinterpret_cast<SceneCheatCode *>(
 					SceneManager::getScene(SceneNames::CHEAT_CODE)
 				);
-				scCheatCode.logerr(e.what());
+				scCheatCode.clearAllLn();
+				std::stringstream ss;
+				ss << "Level " << _currentLvl << ": " << e.what();
+				scCheatCode.logerr(ss.str());
 				scCheatCode.unlockLevel(_currentLvl + 1);
 				SceneManager::loadScene(SceneNames::LEVEL_SELECTION);
 				return true;

--- a/srcs/scenes/SceneLevelSelection.cpp
+++ b/srcs/scenes/SceneLevelSelection.cpp
@@ -2,6 +2,7 @@
 #include "SceneGame.hpp"
 #include "Save.hpp"
 #include "SceneCheatCode.hpp"
+#include "SceneManager.hpp"
 
 SceneLevelSelection::SceneLevelSelection(Gui * gui, float const &dtTime)
 : ASceneMenu(gui, dtTime),
@@ -109,6 +110,7 @@ bool	SceneLevelSelection::update() {
 	glm::vec2 winSz = _gui->gameInfo.windowSize;
 	// SceneGame reference
 	SceneGame & scGame = *reinterpret_cast<SceneGame *>(SceneManager::getScene(SceneNames::GAME));
+	SceneCheatCode & scCheatCode = *reinterpret_cast<SceneCheatCode *>(SceneManager::getScene(SceneNames::CHEAT_CODE));
 
 	allUI.text->setText("Level " + std::to_string(_currentLvl));
 	if (Save::isLevelDone(_currentLvl)) {
@@ -145,7 +147,10 @@ bool	SceneLevelSelection::update() {
 				}
 			} catch (std::exception const &e) {
 				logErr("Error: " << e.what());
-				return false;
+				scCheatCode.logerr(e.what());
+				scCheatCode.unlockLevel(_currentLvl + 1);
+				SceneManager::loadScene(SceneNames::LEVEL_SELECTION);
+				return true;
 			}
 			SceneManager::loadScene(SceneNames::GAME);
 			return true;

--- a/srcs/scenes/SceneVictory.cpp
+++ b/srcs/scenes/SceneVictory.cpp
@@ -160,7 +160,10 @@ bool	SceneVictory::update() {
 					SceneManager::getScene(SceneNames::CHEAT_CODE)
 				);
 				logErr("Error: " << e.what());
-				scCheatCode.logerr(e.what());
+				scCheatCode.clearAllLn();
+				std::stringstream ss;
+				ss << "Level " << scGame.level << ": " << e.what();
+				scCheatCode.logerr(ss.str());
 				scCheatCode.unlockLevel(scGame.level + 1);
 				SceneManager::loadScene(SceneNames::LEVEL_SELECTION);
 				return true;

--- a/srcs/scenes/SceneVictory.cpp
+++ b/srcs/scenes/SceneVictory.cpp
@@ -1,5 +1,6 @@
 #include "SceneVictory.hpp"
 #include "SceneGame.hpp"
+#include "SceneCheatCode.hpp"
 
 SceneVictory::SceneVictory(Gui * gui, float const &dtTime)
 : ASceneMenu(gui, dtTime),
@@ -155,8 +156,14 @@ bool	SceneVictory::update() {
 					return false;
 				}
 			} catch (std::exception const &e) {
+				SceneCheatCode & scCheatCode = *reinterpret_cast<SceneCheatCode *>(
+					SceneManager::getScene(SceneNames::CHEAT_CODE)
+				);
 				logErr("Error: " << e.what());
-				return false;
+				scCheatCode.logerr(e.what());
+				scCheatCode.unlockLevel(scGame.level + 1);
+				SceneManager::loadScene(SceneNames::LEVEL_SELECTION);
+				return true;
 			}
 			SceneManager::loadScene(_lastSceneName);
 		}


### PR DESCRIPTION
Affichage de l'erreur et le jeu ne quitte pas s'il y a une erreur dans une map.
Le level suivant est débloqué pour permettre au joueur de continuer à jouer.

Ces actions sont aussi faite lorsqu'on gagne un niveau, et que le suivant comporte une erreur. On est redirigé vers le menu de choix de Niveau et le niveau est débloqué.

![image](https://user-images.githubusercontent.com/6124152/79895558-5857ad80-8407-11ea-88a4-393e63055015.png)

Résout les tickets
- fix #88 
- fix #120
