### PR TITLE
Feature/level design

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -366,6 +366,8 @@ elif [[ "$$OSTYPE" == "darwin"* ]]; then
 	# assimp
 	brew install assimp;
 	brew upgrade assimp;
+	# freetype2
+	brew install freetype2
 fi
 
 exit 0

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ SRC =	main.cpp \
 		scenes/ASceneMenu.cpp \
 		scenes/SceneMainMenu.cpp \
 		scenes/SceneLoadGame.cpp \
+		scenes/SceneDifficulty.cpp \
 		scenes/SceneLevelSelection.cpp \
 		scenes/SceneGame.cpp \
 		scenes/ScenePause.cpp \
@@ -211,6 +212,7 @@ HEAD =	bomberman.hpp \
 		scenes/ASceneMenu.hpp \
 		scenes/SceneMainMenu.hpp \
 		scenes/SceneLoadGame.hpp \
+		scenes/SceneDifficulty.hpp \
 		scenes/SceneLevelSelection.hpp \
 		scenes/SceneGame.hpp \
 		scenes/ScenePause.hpp \

--- a/includes/ACharacter.hpp
+++ b/includes/ACharacter.hpp
@@ -8,7 +8,7 @@
 #include "AEntity.hpp"
 
 #define MIN_SPEED 1.0
-#define MAX_SPEED 6.0
+#define MAX_SPEED 7.0
 #define OFFSET_TURN_CORRECTION 0.85
 #define MOVE_STEP 0.05
 

--- a/includes/audio/AudioManager.hpp
+++ b/includes/audio/AudioManager.hpp
@@ -41,6 +41,7 @@
 class AudioManager {
 public:
 	static const int						nb_sound_channels = 42;
+	static std::vector<std::string>			musics;
 
 	~AudioManager();
 

--- a/includes/audio/AudioManager.hpp
+++ b/includes/audio/AudioManager.hpp
@@ -60,7 +60,7 @@ public:
 
 	static void								loadSound(std::string file_name);
 	static void								playSound(std::string sound_name, float volume = 1.0,
-											bool loop = false, bool muteMusic = false);
+											bool loop = false, bool muteMusic = false, int fadeIn = 0);
 	static void								pauseSound(std::string sound_name);
 	static void								resumeSound(std::string sound_name);
 	static void								stopSound(std::string sound_name);
@@ -87,7 +87,7 @@ private:
 
 	void									_loadSound(std::string file_name);
 	void									_playSound(std::string sound_name, float volume = 1.0,
-											bool loop = false, bool muteMusic = false);
+											bool loop = false, bool muteMusic = false, int fadeIn = 0);
 	void									_pauseSound(std::string sound_name);
 	void									_resumeSound(std::string sound_name);
 	void									_stopSound(std::string sound_name);

--- a/includes/audio/AudioManager.hpp
+++ b/includes/audio/AudioManager.hpp
@@ -34,6 +34,7 @@
 #define MONSTERKILL_SOUND "sounds/monster_kill.ogg"
 #define INTROLEVEL_SOUND "sounds/intro_level.ogg"
 #define ALARM_TIME_SOUND "sounds/alarm_time.ogg"
+#define MUSIC_MENU "sounds/menu_loop.ogg"
 
 /**
  * @brief This is the audio manager. In this static class, you can play musics and sound

--- a/includes/audio/AudioManager.hpp
+++ b/includes/audio/AudioManager.hpp
@@ -4,6 +4,7 @@
 # include <SDL2/SDL.h>
 # include <SDL2/SDL_mixer.h>
 # include <map>
+# include <unordered_set>
 # include "Sound.hpp"
 # include "Music.hpp"
 
@@ -55,7 +56,8 @@ public:
 	static void								unloadMusic(std::string music_name);
 
 	static void								loadSound(std::string file_name);
-	static void								playSound(std::string sound_name, float volume = 1.0, bool loop = false);
+	static void								playSound(std::string sound_name, float volume = 1.0,
+											bool loop = false, bool muteMusic = false);
 	static void								pauseSound(std::string sound_name);
 	static void								resumeSound(std::string sound_name);
 	static void								stopSound(std::string sound_name);
@@ -81,7 +83,8 @@ private:
 	void									_unloadMusic(std::string music_name);
 
 	void									_loadSound(std::string file_name);
-	void									_playSound(std::string sound_name, float volume = 1.0, bool loop = false);
+	void									_playSound(std::string sound_name, float volume = 1.0,
+											bool loop = false, bool muteMusic = false);
 	void									_pauseSound(std::string sound_name);
 	void									_resumeSound(std::string sound_name);
 	void									_stopSound(std::string sound_name);
@@ -99,6 +102,8 @@ private:
 	std::map<std::string, Music *>			_musics;
 	std::map<std::string, Sound *>			_sounds;
 	bool									_enabled;
+	std::unordered_set<int>					_soundsMutesMusic;
+	bool									_musicPaused;
 };
 
 #endif

--- a/includes/audio/AudioManager.hpp
+++ b/includes/audio/AudioManager.hpp
@@ -4,6 +4,7 @@
 # include <SDL2/SDL.h>
 # include <SDL2/SDL_mixer.h>
 # include <map>
+# include <vector>
 # include <unordered_set>
 # include "Sound.hpp"
 # include "Music.hpp"

--- a/includes/audio/Sound.hpp
+++ b/includes/audio/Sound.hpp
@@ -23,7 +23,7 @@ public:
 	explicit Sound(std::string filename);
 	~Sound();
 
-	int											play(float volume, float env_volume, bool loop = false);
+	int											play(float volume, float env_volume, bool loop = false, int fadeIn = 0);
 	void										pause();
 	void										resume();
 	void										stop();

--- a/includes/audio/Sound.hpp
+++ b/includes/audio/Sound.hpp
@@ -23,7 +23,7 @@ public:
 	explicit Sound(std::string filename);
 	~Sound();
 
-	void										play(float volume, float env_volume, bool loop = false);
+	int											play(float volume, float env_volume, bool loop = false);
 	void										pause();
 	void										resume();
 	void										stop();

--- a/includes/elements/Bonus.hpp
+++ b/includes/elements/Bonus.hpp
@@ -31,6 +31,7 @@ private:
 	// Member
 	BonusType::Enum		_typeBonus;
 	static std::map<BonusType::Enum, Block::Enum> _textures;
+	int					_toDraw;
 	// Methods
 	BonusType::Enum		_pickBonus();
 

--- a/includes/elements/Player.hpp
+++ b/includes/elements/Player.hpp
@@ -23,6 +23,7 @@ private:
 	void	_move();
 	bool	_putBomb();
 	void	_updateAnimationState();
+	void	_updateBonusActifsTime();
 
 public:
 	// Members
@@ -34,6 +35,18 @@ public:
 	bool		passBomb;
 	int			bombProgation;
 	float		invulnerable;
+
+	struct BonusActifs {
+		float	life;
+		float	bombs;
+		float	flames;
+		float	speed;
+		float	wallpass;
+		float	detonator;
+		float	bombpass;
+		float	flampass;
+	};
+	BonusActifs		bonusActifs;
 
 	// Constructors
 	explicit Player(SceneGame &game);

--- a/includes/elements/Player.hpp
+++ b/includes/elements/Player.hpp
@@ -21,7 +21,7 @@ private:
 
 	// Methods
 	void	_move();
-	void	_putBomb();
+	bool	_putBomb();
 	void	_updateAnimationState();
 
 public:

--- a/includes/elements/Player.hpp
+++ b/includes/elements/Player.hpp
@@ -38,6 +38,8 @@ public:
 
 	struct BonusActifs {
 		float	life;
+		float	score;
+		float	time;
 		float	bombs;
 		float	flames;
 		float	speed;
@@ -45,6 +47,7 @@ public:
 		float	detonator;
 		float	bombpass;
 		float	flampass;
+		float	shield;
 	};
 	BonusActifs		bonusActifs;
 

--- a/includes/elements/Save.hpp
+++ b/includes/elements/Save.hpp
@@ -41,7 +41,7 @@ public:
 	static void			deleteTemp();
 	static std::time_t	filenameToTimestamp(std::string filename, bool temporary);
 	static std::string	timestampToFileName(time_t timestamp);
-	static int			getLastLevel();
+	static int			getLastUnlockedLevel();
 	// Exceptions
 	class SaveException : public std::runtime_error {
 	public:
@@ -72,7 +72,7 @@ private:
 	void				_init();
 	bool				_isLevelDone(int32_t levelId);
 	bool				_setLevelDone(int32_t levelId, int32_t score);
-	int					_getLastLevel();
+	int					_getLastUnlockedLevel();
 	bool				_save(bool temporary);
 	bool				_updateSavedFile(SceneGame &game, bool succeedLevel);
 	bool				_loadStatesSaved(SceneGame &game);

--- a/includes/elements/Save.hpp
+++ b/includes/elements/Save.hpp
@@ -41,6 +41,7 @@ public:
 	static void			deleteTemp();
 	static std::time_t	filenameToTimestamp(std::string filename, bool temporary);
 	static std::string	timestampToFileName(time_t timestamp);
+	static int			getLastLevel();
 	// Exceptions
 	class SaveException : public std::runtime_error {
 	public:
@@ -71,6 +72,7 @@ private:
 	void				_init();
 	bool				_isLevelDone(int32_t levelId);
 	bool				_setLevelDone(int32_t levelId, int32_t score);
+	int					_getLastLevel();
 	bool				_save(bool temporary);
 	bool				_updateSavedFile(SceneGame &game, bool succeedLevel);
 	bool				_loadStatesSaved(SceneGame &game);

--- a/includes/elements/Save.hpp
+++ b/includes/elements/Save.hpp
@@ -37,6 +37,8 @@ public:
 	static bool			isLevelDone(int32_t levelId);
 	static int			getLevelScore(int32_t levelId);
 	static bool			setLevelDone(int32_t levelId, int32_t score);
+	static void			setDifficulty(uint difficulty);
+	static uint			getDifficulty();
 	static bool			save(bool temporary = false);
 	static void			deleteTemp();
 	static std::time_t	filenameToTimestamp(std::string filename, bool temporary);

--- a/includes/scenes/SceneDifficulty.hpp
+++ b/includes/scenes/SceneDifficulty.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "ASceneMenu.hpp"
+#include "ABaseUI.hpp"
+
+/**
+ * @brief main menu (opened at the game startup)
+ */
+class SceneDifficulty : public ASceneMenu {
+	public:
+		// Constructors
+		SceneDifficulty(Gui * gui, float const &dtTime);
+		virtual ~SceneDifficulty();
+		SceneDifficulty(SceneDifficulty const &src);
+
+		// Operators
+		SceneDifficulty &operator=(SceneDifficulty const &rhs);
+		friend std::ostream& operator<<(std::ostream& os, const SceneDifficulty& myClass);
+
+		// Methods
+		virtual bool		init();
+		virtual void		load();
+		virtual bool		update();
+
+	protected:
+		struct ButtonsStates {
+			bool	easy;
+			bool	medium;
+			bool	hardCore;
+			bool	menu;
+		};
+		ButtonsStates	_states;
+		struct AllUI {
+			ABaseUI	*easy;
+			ABaseUI	*medium;
+			ABaseUI	*hardCore;
+			ABaseUI	*menu;
+			ABaseUI	*border;
+		};
+		AllUI		allUI;
+
+
+	private:
+		SceneDifficulty();
+		void		_updateUI();
+};

--- a/includes/scenes/SceneDifficulty.hpp
+++ b/includes/scenes/SceneDifficulty.hpp
@@ -24,6 +24,7 @@ class SceneDifficulty : public ASceneMenu {
 
 	protected:
 		struct ButtonsStates {
+			bool	beginner;
 			bool	easy;
 			bool	medium;
 			bool	hardCore;
@@ -31,6 +32,7 @@ class SceneDifficulty : public ASceneMenu {
 		};
 		ButtonsStates	_states;
 		struct AllUI {
+			ABaseUI	*beginner;
 			ABaseUI	*easy;
 			ABaseUI	*medium;
 			ABaseUI	*hardCore;

--- a/includes/scenes/SceneDifficulty.hpp
+++ b/includes/scenes/SceneDifficulty.hpp
@@ -36,7 +36,6 @@ class SceneDifficulty : public ASceneMenu {
 			ABaseUI	*easy;
 			ABaseUI	*medium;
 			ABaseUI	*hardCore;
-			ABaseUI	*menu;
 			ABaseUI	*border;
 		};
 		AllUI		allUI;

--- a/includes/scenes/SceneGame.hpp
+++ b/includes/scenes/SceneGame.hpp
@@ -134,6 +134,7 @@ public:
 	Score						score;
 	int64_t						enemiesToKill;
 	int64_t						enemiesKilled;
+	std::string					musicLevel;
 
 	// Constructors
 	SceneGame(Gui * gui, float const &dtTime);

--- a/includes/scenes/SceneGame.hpp
+++ b/includes/scenes/SceneGame.hpp
@@ -87,6 +87,7 @@ protected:
 		ABaseUI *	scoreText;  // TextUI
 		ABaseUI *	lifeImg;  // ImageUI
 		ABaseUI *	lifeText;  // TextUI
+		ABaseUI *	levelNameText;  // TextUI
 		ABaseUI *	enemiesCounterText;  // TextUI
 		ABaseUI *	speedImg;  // ImageUI
 		ABaseUI *	speedText;  // TextUI

--- a/includes/scenes/SceneGame.hpp
+++ b/includes/scenes/SceneGame.hpp
@@ -81,26 +81,36 @@ private:
 protected:
 	struct AllUI {
 		ABaseUI *	introText;  // TextUI
-
-		ABaseUI *	timeLeftImg;  // TextUI
+		ABaseUI *	timeLeftImg;  // ImageUI
+		ABaseUI *	timeLeftImgActive;  // ImageUI
 		ABaseUI *	timeLeftText;  // TextUI
-		ABaseUI *	scoreImg;  // TextUI
+		ABaseUI *	scoreImg;  // ImageUI
+		ABaseUI *	scoreImgActive;  // ImageUI
 		ABaseUI *	scoreText;  // TextUI
 		ABaseUI *	lifeImg;  // ImageUI
+		ABaseUI *	lifeImgActive;  // ImageUI
 		ABaseUI *	lifeText;  // TextUI
 		ABaseUI *	levelNameText;  // TextUI
 		ABaseUI *	enemiesCounterText;  // TextUI
 		ABaseUI *	speedImg;  // ImageUI
+		ABaseUI *	speedImgActive;  // ImageUI
 		ABaseUI *	speedText;  // TextUI
 		ABaseUI *	bonusBombImg;  // ImageUI
+		ABaseUI *	bonusBombImgActive;  // ImageUI
 		ABaseUI *	bonusBombText;  // TextUI
 		ABaseUI *	bonusFlameImg;  // ImageUI
+		ABaseUI *	bonusFlameImgActive;  // ImageUI
 		ABaseUI *	bonusFlameText;  // TextUI
 		ABaseUI *	bonusFlampassImg;  // ImageUI
+		ABaseUI *	bonusFlampassImgActive;  // ImageUI
 		ABaseUI *	bonusWallpassImg;  // ImageUI
+		ABaseUI *	bonusWallpassImgActive;  // ImageUI
 		ABaseUI *	bonusDetonatorImg;  // ImageUI
+		ABaseUI *	bonusDetonatorImgActive;  // ImageUI
 		ABaseUI *	bonusBombpassImg;  // ImageUI
+		ABaseUI *	bonusBombpassImgActive;  // ImageUI
 		ABaseUI *	bonusShieldImg;  // ImageUI
+		ABaseUI *	bonusShieldImgActive;  // ImageUI
 		ABaseUI *	bonusShieldText;  // TextUI
 	};
 	AllUI			allUI;

--- a/includes/scenes/SceneLoadGame.hpp
+++ b/includes/scenes/SceneLoadGame.hpp
@@ -40,6 +40,7 @@ class SceneLoadGame : public ASceneMenu {
 		struct PreviewGame {
 			ABaseUI *	title;
 			ABaseUI *	date;
+			ABaseUI *	gameDifficulty;
 			ABaseUI *	levelsDone;
 			ABaseUI *	scoreTotal;
 			ABaseUI *	loadGame;

--- a/includes/scenes/SceneManager.hpp
+++ b/includes/scenes/SceneManager.hpp
@@ -12,6 +12,7 @@
 namespace SceneNames {
 	static std::string const MAIN_MENU = "mainMenu";
 	static std::string const LEVEL_SELECTION = "levelSelection";
+	static std::string const DIFFICULTY = "difficulty";
 	static std::string const GAME = "game";
 	static std::string const PAUSE = "pause";
 	static std::string const GAME_OVER = "gameOver";

--- a/srcs/audio/AudioManager.cpp
+++ b/srcs/audio/AudioManager.cpp
@@ -26,6 +26,7 @@ AudioManager::AudioManager(): _music_modifier(1.0) {
 	char	*path = getcwd(NULL, PATH_MAX);
 	AudioManager::_assets_path = std::string(path);
 	AudioManager::_assets_path += "/bomberman-assets/";
+	_musicPaused = false;
 	free(path);
 	// logDebug("Assets_path: " << AudioManager::_assets_path);
 	if (SDL_Init(SDL_INIT_AUDIO) < 0) {
@@ -142,8 +143,10 @@ void						AudioManager::_playMusic(std::string music_name, float volume, bool lo
 		volume = volume > 1.0 ? 1.0 : volume;
 		music->play(volume * _volume_master * _volume_music, loop);
 		_music_modifier = volume;
-		_musicPaused = false;
 		_soundsMutesMusic.clear();
+		if (_musicPaused) {
+			_pauseMusic();
+		}
 	}
 	catch (std::out_of_range const &oor) {
 		logErr("Trying to play the music '" << music_name << "' but it has not been loaded.");

--- a/srcs/audio/AudioManager.cpp
+++ b/srcs/audio/AudioManager.cpp
@@ -201,7 +201,7 @@ void						AudioManager::stopMusic() {
 	}
 }
 void						AudioManager::_stopMusic() {
-	Mix_HaltMusic();
+	Mix_FadeOutMusic(2000);
 }
 
 /**
@@ -259,20 +259,20 @@ void						AudioManager::_loadSound(std::string file_name) {
  *
  * @throw A SoundException if the sound failed to be played.
  */
-void						AudioManager::playSound(std::string sound_name, float volume, bool loop, bool muteMusic) {
+void						AudioManager::playSound(std::string sound_name, float volume, bool loop, bool muteMusic, int fadeIn) {
 	AudioManager &inst = AudioManager::get();
 	if (inst._enabled) {
-		AudioManager::get()._playSound(sound_name, volume, loop, muteMusic);
+		AudioManager::get()._playSound(sound_name, volume, loop, muteMusic, fadeIn);
 	}
 	else {
 		logWarn("AudioManager is not enabled.");
 	}
 }
-void						AudioManager::_playSound(std::string sound_name, float volume, bool loop, bool muteMusic) {
+void						AudioManager::_playSound(std::string sound_name, float volume, bool loop, bool muteMusic, int fadeIn) {
 	try {
 		Sound	*sound = _sounds.at(sound_name);
 		volume = volume > 1.0 ? 1.0 : volume;
-		int chan = sound->play(volume, _volume_master * _volume_sound, loop);
+		int chan = sound->play(volume, _volume_master * _volume_sound, loop, fadeIn);
 		if (muteMusic) {
 			pauseMusic();
 			_soundsMutesMusic.insert(chan);

--- a/srcs/audio/AudioManager.cpp
+++ b/srcs/audio/AudioManager.cpp
@@ -6,7 +6,21 @@
 #include "Logging.hpp"
 #include "bomberman.hpp"
 
+// -- Static members -----------------------------------------------------------
+
 std::string					AudioManager::_assets_path = std::string();
+
+std::vector<std::string> AudioManager::musics = {
+	"sounds/french79-between_the_buttons.ogg",
+	"sounds/french79-naked_city.ogg",
+	"sounds/superpoze-siver_head.ogg",
+	"sounds/the_blaze-territory.ogg",
+	"sounds/eirik_suhrke-a_new_morning.ogg",
+	"sounds/moon-crystals.ogg",
+	"sounds/moon-hydrogen.ogg"
+};
+
+// -- Methods ------------------------------------------------------------------
 
 AudioManager::AudioManager(): _music_modifier(1.0) {
 	char	*path = getcwd(NULL, PATH_MAX);

--- a/srcs/audio/AudioManager.cpp
+++ b/srcs/audio/AudioManager.cpp
@@ -48,27 +48,29 @@ AudioManager::~AudioManager() {
 }
 
 /**
-	Return a reference to the singleton AudioManager.
-
-	@return the reference to the singleton.
-*/
+ * @brief Return a reference to the singleton AudioManager.
+ *
+ * @return AudioManager& the reference to the singleton.
+ */
 AudioManager				&AudioManager::get() {
 	static AudioManager		instance;
 	return (instance);
 }
 
 /**
-	Indicate if the AudioManager has been correctly initialized.
-
-	@return true if the AudioManager is working.
-*/
+ * @brief Indicate if the AudioManager has been correctly initialized.
+ *
+ * @return true if the AudioManager is working.
+ * @return false otherwise.
+ */
 bool						AudioManager::isEnabled() {
 	return AudioManager::get()._enabled;
 }
+
 /**
- 	Change the volume for the music and all the sound being played.
-	If the music was set with a volume modifier lower than 1.0, it will be conserved.
-*/
+ * @brief Change the volume for the music and all the sound being played.
+ * If the music was set with a volume modifier lower than 1.0, it will be conserved.
+ */
 void						AudioManager::updateSettings() {
 	AudioManager::get()._updateSettings();
 }
@@ -82,14 +84,13 @@ void						AudioManager::_updateSettings() {
 	}
 }
 
-
 /**
-	Load a new music from its file name.
-
-	@param file_name The path to the music file, starting from the asset directory.
-
-	@throw A MusicException if the music failed to be loaded. The path might be incorrect.
-*/
+ * @brief Load a new music from its file name.
+ *
+ * @param file_name The path to the music file, starting from the asset directory.
+ *
+ * @throw A MusicException if the music failed to be loaded. The path might be incorrect.
+ */
 void						AudioManager::loadMusic(std::string file_name) {
 	AudioManager &inst = AudioManager::get();
 	if (inst._enabled) {
@@ -104,13 +105,14 @@ void						AudioManager::_loadMusic(std::string file_name) {
 }
 
 /**
-	Play a music with a volume modifier.
-
-	@param volume The volume modifier apply on top of the audio setting. Set to 1.0 by default.
-	@param loop Indicate if the music should loop. false by default.
-
-	@throw A MusicException if the music failed to be played.
-*/
+ * @brief Play a music with a volume modifier.
+ *
+ * @param music_name The name of the file of the music we want to play.
+ * @param volume The volume modifier apply on top of the audio setting. Set to 1.0 by default.
+ * @param loop Indicate if the music should loop. false by default.
+ *
+ * @throw A MusicException if the music failed to be played.
+ */
 void						AudioManager::playMusic(std::string music_name, float volume, bool loop) {
 	AudioManager &inst = AudioManager::get();
 	if (inst._enabled) {
@@ -126,6 +128,8 @@ void						AudioManager::_playMusic(std::string music_name, float volume, bool lo
 		volume = volume > 1.0 ? 1.0 : volume;
 		music->play(volume * _volume_master * _volume_music, loop);
 		_music_modifier = volume;
+		_musicPaused = false;
+		_soundsMutesMusic.clear();
 	}
 	catch (std::out_of_range const &oor) {
 		logErr("Trying to play the music '" << music_name << "' but it has not been loaded.");
@@ -134,8 +138,8 @@ void						AudioManager::_playMusic(std::string music_name, float volume, bool lo
 }
 
 /**
-	Pause the music currently played.
-*/
+ * @brief Pause the music currently played.
+ */
 void						AudioManager::pauseMusic() {
 	AudioManager &inst = AudioManager::get();
 	if (inst._enabled) {
@@ -147,11 +151,12 @@ void						AudioManager::pauseMusic() {
 }
 void						AudioManager::_pauseMusic() {
 	Mix_PauseMusic();
+	_musicPaused = true;
 }
 
 /**
-	Resume the music currently played.
-*/
+ * @brief Resume the music currently played.
+ */
 void						AudioManager::resumeMusic() {
 	AudioManager &inst = AudioManager::get();
 	if (inst._enabled) {
@@ -163,11 +168,12 @@ void						AudioManager::resumeMusic() {
 }
 void						AudioManager::_resumeMusic() {
 	Mix_ResumeMusic();
+	_musicPaused = false;
 }
 
 /**
-	Stop the music currently played.
-*/
+ * @brief Stop the music currently played.
+ */
 void						AudioManager::stopMusic() {
 	AudioManager &inst = AudioManager::get();
 	if (inst._enabled) {
@@ -182,10 +188,10 @@ void						AudioManager::_stopMusic() {
 }
 
 /**
-	Unload the music from the audio manager.
-
-	@param file_name The path to the music file, starting from the asset directory.
-*/
+ * @brief Unload the music from the audio manager.
+ *
+ * @param music_name The path to the music file, starting from the asset directory.
+ */
 void						AudioManager::unloadMusic(std::string music_name) {
 	AudioManager &inst = AudioManager::get();
 	if (inst._enabled) {
@@ -206,14 +212,13 @@ void						AudioManager::_unloadMusic(std::string music_name) {
 	}
 }
 
-
 /**
-	Load a new sound from its file name.
-
-	@param file_name The path to the sound file, starting from the asset directory.
-
-	@throw A SoundException if the sound failed to be loaded. The path might be incorrect.
-*/
+ * @brief Load a new sound from its file name.
+ *
+ * @param file_name The path to the sound file, starting from the asset directory.
+ *
+ * @throw A SoundException if the sound failed to be loaded. The path might be incorrect.
+ */
 void						AudioManager::loadSound(std::string file_name) {
 	AudioManager &inst = AudioManager::get();
 	if (inst._enabled) {
@@ -228,27 +233,33 @@ void						AudioManager::_loadSound(std::string file_name) {
 }
 
 /**
-	Play a sound identified by file name with a volume modifier.
-
-	@param sound_name the file name of the sound.
-	@param volume The volume modifier apply on top of the audio setting. Set to 1.0 by default.
-
-	@throw A SoundException if the sound failed to be played.
-*/
-void						AudioManager::playSound(std::string sound_name, float volume, bool loop) {
+ * @brief Play a sound identified by file name with a volume modifier.
+ *
+ * @param sound_name the file name of the sound.
+ * @param volume The volume modifier apply on top of the audio setting. Set to 1.0 by default.
+ * @param loop If the sound is played on loop.
+ * @param muteMusic If we need to mute the music during the sound.
+ *
+ * @throw A SoundException if the sound failed to be played.
+ */
+void						AudioManager::playSound(std::string sound_name, float volume, bool loop, bool muteMusic) {
 	AudioManager &inst = AudioManager::get();
 	if (inst._enabled) {
-		AudioManager::get()._playSound(sound_name, volume, loop);
+		AudioManager::get()._playSound(sound_name, volume, loop, muteMusic);
 	}
 	else {
 		logWarn("AudioManager is not enabled.");
 	}
 }
-void						AudioManager::_playSound(std::string sound_name, float volume, bool loop) {
+void						AudioManager::_playSound(std::string sound_name, float volume, bool loop, bool muteMusic) {
 	try {
 		Sound	*sound = _sounds.at(sound_name);
 		volume = volume > 1.0 ? 1.0 : volume;
-		sound->play(volume,  _volume_master * _volume_sound, loop);
+		int chan = sound->play(volume, _volume_master * _volume_sound, loop);
+		if (muteMusic) {
+			pauseMusic();
+			_soundsMutesMusic.insert(chan);
+		}
 	}
 	catch (std::out_of_range const &oor) {
 		logErr("Trying to play the sound '" << sound_name << "' but it has not been loaded.");
@@ -257,10 +268,10 @@ void						AudioManager::_playSound(std::string sound_name, float volume, bool lo
 }
 
 /**
-	Pause all the channels of the sound identified by file name.
-
-	@param sound_name the file name of the sound.
-*/
+ * @brief Pause all the channels of the sound identified by file name.
+ *
+ * @param sound_name the file name of the sound.
+ */
 void						AudioManager::pauseSound(std::string sound_name) {
 	AudioManager &inst = AudioManager::get();
 	if (inst._enabled) {
@@ -307,10 +318,10 @@ void						AudioManager::_resumeSound(std::string sound_name) {
 }
 
 /**
-	Stop all the channels of the sound identified by file name.
-
-	@param sound_name the file name of the sound.
-*/
+ * @brief Stop all the channels of the sound identified by file name.
+ *
+ * @param sound_name the file name of the sound.
+ */
 void						AudioManager::stopSound(std::string sound_name) {
 	AudioManager &inst = AudioManager::get();
 	if (inst._enabled) {
@@ -332,8 +343,8 @@ void						AudioManager::_stopSound(std::string sound_name) {
 }
 
 /**
-	Pause all the channels.
-*/
+ * @brief Pause all the channels.
+ */
 void						AudioManager::pauseAllSounds() {
 	AudioManager &inst = AudioManager::get();
 	if (inst._enabled) {
@@ -348,8 +359,8 @@ void						AudioManager::_pauseAllSounds() {
 }
 
 /**
-	Resume all the channels.
-*/
+ * @brief Resume all the channels.
+ */
 void						AudioManager::resumeAllSounds() {
 	AudioManager &inst = AudioManager::get();
 	if (inst._enabled) {
@@ -364,10 +375,10 @@ void						AudioManager::_resumeAllSounds() {
 }
 
 /**
-	Unload the sound identified by file name.
-
-	@param sound_name the file name of the sound.
-*/
+ * @brief Unload the sound identified by file name.
+ *
+ * @param sound_name the file name of the sound.
+ */
 void						AudioManager::unloadSound(std::string sound_name) {
 	AudioManager &inst = AudioManager::get();
 	if (inst._enabled) {
@@ -389,8 +400,8 @@ void						AudioManager::_unloadSound(std::string sound_name) {
 }
 
 /**
-	Stop all the channels.
-*/
+ * @brief Stop all the channels.
+ */
 void						AudioManager::stopAllSounds() {
 	AudioManager &inst = AudioManager::get();
 	if (inst._enabled) {
@@ -404,8 +415,21 @@ void						AudioManager::_stopAllSounds() {
 	Mix_HaltChannel(-1);
 }
 
+/**
+ * @brief Callback called when a music or sound finish.
+ *
+ * @param chan channel used by the sound.
+ */
 void						AudioManager::_channelHalted(int chan) {
 	AudioManager	&inst = AudioManager::get();
+	std::unordered_set<int>::const_iterator got = inst._soundsMutesMusic.find(chan);
+	if (got != inst._soundsMutesMusic.end())
+		inst._soundsMutesMusic.erase(chan);
+	if (inst._musicPaused) {
+		if (!inst._soundsMutesMusic.size()) {
+			resumeMusic();
+		}
+	}
 	for (auto it = inst._sounds.begin(); it != inst._sounds.end(); it++) {
 		it->second->channelFinished(chan);
 	}

--- a/srcs/audio/Music.cpp
+++ b/srcs/audio/Music.cpp
@@ -30,7 +30,7 @@ Music::~Music() {
  */
 void						Music::play(float volume, bool loop) {
 	if (_mix_mus != nullptr) {
-		if (Mix_PlayMusic(_mix_mus, loop ? -1 : 0) != 0) {
+		if (Mix_FadeInMusic(_mix_mus, loop ? -1 : 0, 2000) != 0) {
 			throw Music::MusicException(Mix_GetError());
 		}
 		Mix_VolumeMusic(static_cast<int>(volume * MIX_MAX_VOLUME));

--- a/srcs/audio/Music.cpp
+++ b/srcs/audio/Music.cpp
@@ -21,12 +21,12 @@ Music::~Music() {
 }
 
 /**
-	Play the music at the specified volume.
-
-	@param volume The volume of the music.
-	@param loop Specify if the music should loop, false by default.
-
-	@throw A MusicException if the music failed to be played.
+ * @brief Play the music at the specified volume.
+ *
+ * @param volume The volume of the music.
+ * @param loop Specify if the music should loop, false by default.
+ *
+ * @throw A MusicException if the music failed to be played.
  */
 void						Music::play(float volume, bool loop) {
 	if (_mix_mus != nullptr) {

--- a/srcs/audio/Sound.cpp
+++ b/srcs/audio/Sound.cpp
@@ -23,14 +23,15 @@ Sound::~Sound() {
 }
 
 /**
-	Play the sound at the specified volume.
-
-	@param volume The volume of the sound.
-	@param env_volume The volume settings.
-
-	@throw A SoundException if the sound failed to be played. Not enough channels are allocated.
+ * @brief Play the sound at the specified volume.
+ *
+ * @param volume The volume of the sound.
+ * @param env_volume The volume settings.
+ * @param loop If the sound is on loop.
+ * @return int channel used.
+ * @throw A SoundException if the sound failed to be played. Not enough channels are allocated.
  */
-void										Sound::play(float volume, float env_volume, bool loop) {
+int										Sound::play(float volume, float env_volume, bool loop) {
 	int			chan;
 
 	if (_chunk != nullptr) {
@@ -42,12 +43,14 @@ void										Sound::play(float volume, float env_volume, bool loop) {
 		Mix_Volume(chan, static_cast<int>(volume * env_volume * MIX_MAX_VOLUME));
 		_currents_channels.insert(chan);
 		_chan_volume.insert(std::pair<int, float>(chan, volume));
+		return chan;
 	}
+	return -2;
 }
 
 /**
-	Pause all the channels playing this sound.
-*/
+ * @brief Pause all the channels playing this sound.
+ */
 void										Sound::pause() {
 	for (auto it = _currents_channels.begin(); it != _currents_channels.end(); it++) {
 		Mix_Pause(*it);
@@ -55,8 +58,8 @@ void										Sound::pause() {
 }
 
 /**
-	Resumes all the channels playing this sound.
-*/
+ * @brief Resumes all the channels playing this sound.
+ */
 void										Sound::resume() {
 	for (auto it = _currents_channels.begin(); it != _currents_channels.end(); it++) {
 		Mix_Resume(*it);
@@ -64,8 +67,8 @@ void										Sound::resume() {
 }
 
 /**
-	Stop all the channels playing this sound.
-*/
+ * @brief Stop all the channels playing this sound.
+ */
 void										Sound::stop() {
 	std::unordered_set<int>::iterator it = _currents_channels.begin();
 	while (it != _currents_channels.end()) {
@@ -75,11 +78,12 @@ void										Sound::stop() {
 }
 
 /**
-	Update the volume for all the channels playing this sound.
-	If a channel was set with volume modifier below 1.0, the modifier will be conserved.
-
-	@param volume The new global volume value.
-*/
+ * @brief Update the volume for all the channels playing this sound.
+ * If a channel was set with volume modifier below 1.0, the modifier will be
+ * conserved.
+ *
+ * @param volume The new global volume value.
+ */
 void										Sound::updateVolume(float volume) {
 	for (auto it = _currents_channels.begin(); it != _currents_channels.end(); it++) {
 		Mix_Volume(*it, _chan_volume.at(*it) * volume * MIX_MAX_VOLUME);
@@ -87,12 +91,12 @@ void										Sound::updateVolume(float volume) {
 }
 
 /**
-	Remove the specified channel from the list of used channels if found in it.
-
-	@param chan The id of the channel that has just finished playing.
-
-	@return true if the channel was found, false otherwise.
-*/
+ * @brief Remove the specified channel from the list of used channels if found in it.
+ *
+ * @param chan The id of the channel that has just finished playing.
+ * @return true if the channel was found.
+ * @return false otherwise.
+ */
 bool										Sound::channelFinished(int chan) {
 	if (_currents_channels.find(chan) != _currents_channels.end()) {
 		_currents_channels.erase(chan);

--- a/srcs/audio/Sound.cpp
+++ b/srcs/audio/Sound.cpp
@@ -31,11 +31,11 @@ Sound::~Sound() {
  * @return int channel used.
  * @throw A SoundException if the sound failed to be played. Not enough channels are allocated.
  */
-int										Sound::play(float volume, float env_volume, bool loop) {
+int										Sound::play(float volume, float env_volume, bool loop, int fadeIn) {
 	int			chan;
 
 	if (_chunk != nullptr) {
-		chan = Mix_PlayChannel(-1, _chunk, loop ? -1 : 0);
+		chan = Mix_FadeInChannel(-1, _chunk, loop ? -1 : 0, fadeIn);
 		if (chan < 0) {
 			throw Sound::SoundException(Mix_GetError());
 		}

--- a/srcs/elements/Bonus.cpp
+++ b/srcs/elements/Bonus.cpp
@@ -171,8 +171,8 @@ std::string	Bonus::getDescription(BonusType::Enum type) {
 /**
  * @brief Static class to generate bonus.
  *
- * @param game
- * @param rate Probability to generate an enemy (between 0 and 1). default: 0.1f
+ * @param game SceneGame object.
+ * @param rate Probability to generate an bonus (between 0 and 1). default: 0.1f
  * @return Bonus* or nullptr if nothing has been generated.
  */
 Bonus	*Bonus::generateBonus(SceneGame &game, float rate) {

--- a/srcs/elements/Bonus.cpp
+++ b/srcs/elements/Bonus.cpp
@@ -40,6 +40,7 @@ Bonus::Bonus(SceneGame &game) : AObject(game) {
 	name = "Bonus";
 	blockPropagation = false;
 	destructible = true;
+	_toDraw = 0;
 	_timeToDie = 10.0f;
 	_typeBonus = _pickBonus();
 	AudioManager::loadSound(BONUS_SOUND);
@@ -61,6 +62,7 @@ Bonus &Bonus::operator=(Bonus const &rhs) {
 	if ( this != &rhs ) {
 		AObject::operator=(rhs);
 		_typeBonus = rhs._typeBonus;
+		_toDraw = rhs._toDraw;
 	}
 	return *this;
 }
@@ -128,6 +130,11 @@ bool	Bonus::postUpdate() {
  * @return false if failure
  */
 bool	Bonus::draw(Gui &gui) {
+	if (_timeToDie <= 2) {
+		_toDraw = ((_toDraw + 1) % 10);
+		if (_toDraw > 5)
+			return true;
+	}
 	gui.drawCube(_textures[_typeBonus], getPos());
 	return true;
 }

--- a/srcs/elements/Player.cpp
+++ b/srcs/elements/Player.cpp
@@ -116,6 +116,8 @@ void	Player::resetParams() {
 	detonator = false;
 	passBomb = false;
 	bonusActifs.life = 0.0f;
+	bonusActifs.score = 0.0f;
+	bonusActifs.time = 0.0f;
 	bonusActifs.bombs = 0.0f;
 	bonusActifs.flames = 0.0f;
 	bonusActifs.speed = 0.0f;
@@ -123,6 +125,7 @@ void	Player::resetParams() {
 	bonusActifs.detonator = 0.0f;
 	bonusActifs.bombpass = 0.0f;
 	bonusActifs.flampass = 0.0f;
+	bonusActifs.shield = 0.0f;
 	resetCrossable();
 }
 
@@ -306,12 +309,18 @@ bool	Player::takeBonus(BonusType::Enum bonus, bool silent) {
 			break;
 		case BonusType::SHIELD:
 			invulnerable += 10.0f;
+			if (!silent)
+				bonusActifs.shield = 3.0f;
 			break;
 		case BonusType::TIME:
 			game.time -= 15.0f;
+			if (!silent)
+				bonusActifs.time = 3.0f;
 			break;
 		case BonusType::POINTS:
 			game.score += 1500;
+			if (!silent)
+				bonusActifs.score = 3.0f;
 			break;
 		default:
 			break;
@@ -394,6 +403,7 @@ bool	Player::rmBonus(BonusType::Enum bonus) {
 			break;
 		case BonusType::POINTS:
 			game.score -= 1500;
+
 			break;
 		default:
 			break;
@@ -546,6 +556,12 @@ void	Player::_updateBonusActifsTime() {
 	if (bonusActifs.life > 0) {
 		bonusActifs.life -= dtTime;
 	}
+	if (bonusActifs.time > 0) {
+		bonusActifs.time -= dtTime;
+	}
+	if (bonusActifs.score > 0) {
+		bonusActifs.score -= dtTime;
+	}
 	if (bonusActifs.bombs > 0) {
 		bonusActifs.bombs -= dtTime;
 	}
@@ -566,6 +582,9 @@ void	Player::_updateBonusActifsTime() {
 	}
 	if (bonusActifs.flampass > 0) {
 		bonusActifs.flampass -= dtTime;
+	}
+	if (bonusActifs.shield > 0) {
+		bonusActifs.shield -= dtTime;
 	}
 }
 

--- a/srcs/elements/Player.cpp
+++ b/srcs/elements/Player.cpp
@@ -242,13 +242,21 @@ bool	Player::takeBonus(BonusType::Enum bonus) {
 	switch (bonus) {
 		case BonusType::LIFE:
 			lives++;
+			if (lives > 3)
+				lives = 3;
 			break;
 		case BonusType::BOMBS:
 			totalBombs++;
 			bombs++;
+			if (totalBombs > 10)
+				totalBombs = 10;
+			if (bombs > 10)
+				bombs = 10;
 			break;
 		case BonusType::FLAMES:
 			bombProgation++;
+			if (bombProgation > 12)
+				bombProgation = 12;
 			break;
 		case BonusType::SPEED:
 			speed++;

--- a/srcs/elements/Player.cpp
+++ b/srcs/elements/Player.cpp
@@ -1,5 +1,6 @@
 #include "Player.hpp"
 #include "Inputs.hpp"
+#include "Save.hpp"
 #include "AudioManager.hpp"
 
 // -- Constructors -------------------------------------------------------------
@@ -103,6 +104,8 @@ void	Player::resetParams() {
 	speed = 3;
 	alive = true;
 	lives = 2;
+	if (lives > static_cast<int>(Save::getDifficulty()))
+		lives = Save::getDifficulty();
 	invulnerable = 3.0f;
 	_toDraw = 0;
 	bombProgation = 2;
@@ -242,8 +245,8 @@ bool	Player::takeBonus(BonusType::Enum bonus) {
 	switch (bonus) {
 		case BonusType::LIFE:
 			lives++;
-			if (lives > 3)
-				lives = 3;
+			if (lives > static_cast<int>(Save::getDifficulty()))
+				lives = Save::getDifficulty();
 			break;
 		case BonusType::BOMBS:
 			totalBombs++;

--- a/srcs/elements/Player.cpp
+++ b/srcs/elements/Player.cpp
@@ -46,6 +46,7 @@ Player &Player::operator=(Player const &rhs) {
 		detonator = rhs.detonator;
 		passBomb = rhs.passBomb;
 		bombProgation = rhs.bombProgation;
+		bonusActifs = rhs.bonusActifs;
 	}
 	return *this;
 }
@@ -114,6 +115,14 @@ void	Player::resetParams() {
 	passWall = false;
 	detonator = false;
 	passBomb = false;
+	bonusActifs.life = 0.0f;
+	bonusActifs.bombs = 0.0f;
+	bonusActifs.flames = 0.0f;
+	bonusActifs.speed = 0.0f;
+	bonusActifs.wallpass = 0.0f;
+	bonusActifs.detonator = 0.0f;
+	bonusActifs.bombpass = 0.0f;
+	bonusActifs.flampass = 0.0f;
 	resetCrossable();
 }
 
@@ -127,6 +136,7 @@ bool	Player::update() {
 	if (!active)
 		return true;
 
+	_updateBonusActifsTime();
 	if (alive && _entityState.state != EntityState::DROP_BOMB) {
 		// update invulnerability time
 		if (invulnerable > 0.0f)
@@ -243,6 +253,8 @@ bool	Player::takeBonus(BonusType::Enum bonus, bool silent) {
 			lives++;
 			if (lives > static_cast<int>(Save::getDifficulty()))
 				lives = Save::getDifficulty();
+			if (!silent)
+				bonusActifs.life = 3.0f;
 			break;
 		case BonusType::BOMBS:
 			totalBombs++;
@@ -251,32 +263,46 @@ bool	Player::takeBonus(BonusType::Enum bonus, bool silent) {
 				totalBombs = 10;
 			if (bombs > 10)
 				bombs = 10;
+			if (!silent)
+				bonusActifs.bombs = 3.0f;
 			break;
 		case BonusType::FLAMES:
 			bombProgation++;
 			if (bombProgation > 12)
 				bombProgation = 12;
+			if (!silent)
+				bonusActifs.flames = 3.0f;
 			break;
 		case BonusType::SPEED:
 			speed++;
 			if (speed > MAX_SPEED)
 				speed = MAX_SPEED;
+			if (!silent)
+				bonusActifs.speed = 3.0f;
 			break;
 		case BonusType::WALLPASS:
 			if (std::find(crossableTypes.begin(), crossableTypes.end(), Type::CRISPY) == crossableTypes.end())
 				crossableTypes.push_back(Type::CRISPY);
 			passWall = true;
+			if (!silent)
+				bonusActifs.wallpass = 3.0f;
 			break;
 		case BonusType::DETONATOR:
 			detonator = true;
+			if (!silent)
+				bonusActifs.detonator = 3.0f;
 			break;
 		case BonusType::BOMBPASS:
 			passBomb = true;
 			if (std::find(crossableTypes.begin(), crossableTypes.end(), Type::BOMB) == crossableTypes.end())
 				crossableTypes.push_back(Type::BOMB);
+			if (!silent)
+				bonusActifs.bombpass = 3.0f;
 			break;
 		case BonusType::FLAMPASS:
 			passFire = true;
+			if (!silent)
+				bonusActifs.flampass = 3.0f;
 			break;
 		case BonusType::SHIELD:
 			invulnerable += 10.0f;
@@ -489,7 +515,12 @@ void	Player::_move() {
 	}
 }
 
-
+/**
+ * @brief Put bomb methods.
+ *
+ * @return true if the bomb was put
+ * @return false if the bomb cannot be put
+ */
 bool	Player::_putBomb() {
 	if (bombs <= 0)
 		return false;
@@ -504,6 +535,38 @@ bool	Player::_putBomb() {
 		return true;
 	}
 	return false;
+}
+
+/**
+ * @brief Update time left for bonus actifs.
+ * Bonus actifs is used to indicate last taken bonuses
+ */
+void	Player::_updateBonusActifsTime() {
+	float dtTime = game.getDtTime();
+	if (bonusActifs.life > 0) {
+		bonusActifs.life -= dtTime;
+	}
+	if (bonusActifs.bombs > 0) {
+		bonusActifs.bombs -= dtTime;
+	}
+	if (bonusActifs.flames > 0) {
+		bonusActifs.flames -= dtTime;
+	}
+	if (bonusActifs.speed > 0) {
+		bonusActifs.speed -= dtTime;
+	}
+	if (bonusActifs.wallpass > 0) {
+		bonusActifs.wallpass -= dtTime;
+	}
+	if (bonusActifs.detonator > 0) {
+		bonusActifs.detonator -= dtTime;
+	}
+	if (bonusActifs.bombpass > 0) {
+		bonusActifs.bombpass -= dtTime;
+	}
+	if (bonusActifs.flampass > 0) {
+		bonusActifs.flampass -= dtTime;
+	}
 }
 
 // -- Exceptions errors --------------------------------------------------------

--- a/srcs/elements/Player.cpp
+++ b/srcs/elements/Player.cpp
@@ -146,12 +146,6 @@ bool	Player::update() {
 		if (Inputs::getKeyDown(InputType::ACTION)) {
 			if (bombs > 0) {
 				setState(EntityState::DROP_BOMB);
-				try {
-					AudioManager::stopSound(PUT_BOMB_SOUND);
-					AudioManager::playSound(PUT_BOMB_SOUND);
-				} catch(Sound::SoundException const & e) {
-					logErr(e.what());
-				}
 			} else {
 				try {
 					AudioManager::playSound(PUT_BOMB_EMPTY_SOUND);
@@ -446,7 +440,14 @@ void	Player::_updateAnimationState() {
  */
 void	Player::animEndCb(std::string animName) {
 	if (animName == "Armature|drop") {
-		_putBomb();
+		if (_putBomb()) {
+			try {
+				AudioManager::stopSound(PUT_BOMB_SOUND);
+				AudioManager::playSound(PUT_BOMB_SOUND);
+			} catch(Sound::SoundException const & e) {
+				logErr(e.what());
+			}
+		}
 		setState(EntityState::IDLE);
 	}
 	else if (animName == "Armature|death") {
@@ -489,9 +490,9 @@ void	Player::_move() {
 }
 
 
-void	Player::_putBomb() {
+bool	Player::_putBomb() {
 	if (bombs <= 0)
-		return;
+		return false;
 
 	glm::ivec2 intPos = getIntPos();
 	if (game.board[intPos.x][intPos.y].size() == 0) {
@@ -500,7 +501,9 @@ void	Player::_putBomb() {
 		game.board[intPos.x][intPos.y].push_back(bomb);
 		bomb->init();
 		bombs -= 1;
+		return true;
 	}
+	return false;
 }
 
 // -- Exceptions errors --------------------------------------------------------

--- a/srcs/elements/Save.cpp
+++ b/srcs/elements/Save.cpp
@@ -291,13 +291,13 @@ bool	Save::_loadStatesSaved(SceneGame &game) {
 	game.player->bombProgation = _saveJs->j("state").u("flame");
 	game.player->speed = _saveJs->j("state").d("speed");
 	if (_saveJs->j("state").u("detonator") == 1)
-		game.player->takeBonus(Bonus::bonus["detonator"]);
+		game.player->takeBonus(Bonus::bonus["detonator"], true);
 	if (_saveJs->j("state").u("wallpass") == 1)
-		game.player->takeBonus(Bonus::bonus["wallpass"]);
+		game.player->takeBonus(Bonus::bonus["wallpass"], true);
 	if (_saveJs->j("state").u("bombpass") == 1)
-		game.player->takeBonus(Bonus::bonus["bombpass"]);
+		game.player->takeBonus(Bonus::bonus["bombpass"], true);
 	if (_saveJs->j("state").u("flampass") == 1)
-		game.player->takeBonus(Bonus::bonus["flampass"]);
+		game.player->takeBonus(Bonus::bonus["flampass"], true);
 
 	return true;
 }

--- a/srcs/elements/Save.cpp
+++ b/srcs/elements/Save.cpp
@@ -302,6 +302,22 @@ bool	Save::_loadStatesSaved(SceneGame &game) {
 }
 
 /**
+ * @brief Get next level to play
+ *
+ * @return int ID of the level.
+ */
+int		Save::getLastLevel() {
+	return get()._getLastLevel();
+}
+int		Save::_getLastLevel() {
+	int	maxLevel = 0;
+	for (SettingsJson *level : _saveJs->lj("levels").list) {
+		maxLevel = level->i("id") >= maxLevel ? level->i("id") + 1 : maxLevel;
+	}
+	return maxLevel;
+}
+
+/**
  * @brief Check if the Level <levelId> has already been done.
  *
  * @param game

--- a/srcs/elements/Save.cpp
+++ b/srcs/elements/Save.cpp
@@ -302,14 +302,14 @@ bool	Save::_loadStatesSaved(SceneGame &game) {
 }
 
 /**
- * @brief Get next level to play
+ * @brief Get last unclocked level.
  *
- * @return int ID of the level.
+ * @return int ID of the level
  */
-int		Save::getLastLevel() {
-	return get()._getLastLevel();
+int		Save::getLastUnlockedLevel() {
+	return get()._getLastUnlockedLevel();
 }
-int		Save::_getLastLevel() {
+int		Save::_getLastUnlockedLevel() {
 	int	maxLevel = 0;
 	for (SettingsJson *level : _saveJs->lj("levels").list) {
 		maxLevel = level->i("id") >= maxLevel ? level->i("id") + 1 : maxLevel;

--- a/srcs/elements/Save.cpp
+++ b/srcs/elements/Save.cpp
@@ -194,6 +194,7 @@ SettingsJson	*Save::initJson(std::string filename, bool newFile) {
 		jsFile->add<int64_t>("date_creation", time);
 		std::time_t		t = std::time(nullptr);
 		jsFile->add<int64_t>("date_lastmodified", t);
+		jsFile->add<uint64_t>("difficulty", 3);
 
 		SettingsJson	*levelPattern = new SettingsJson();
 		levelPattern->add<int64_t>("id", 0).setMin(0);
@@ -352,7 +353,6 @@ int		Save::_getLevelScore(int32_t levelId) {
 			return level->i("score");
 		}
 	}
-
 	return 0;
 }
 
@@ -383,8 +383,27 @@ bool	Save::_setLevelDone(int32_t levelId, int32_t score) {
 
 		_saveJs->lj("levels").add(levelPattern);
 	}
-
 	return true;
+}
+
+/**
+ * @brief Set difficulty of the game.
+ *
+ * @param difficulty (lower is more difficult)
+ */
+void	Save::setDifficulty(uint difficulty) {
+	get()._saveJs->u("difficulty") = difficulty;
+	if (get()._saveJs->j("state").u("life") > difficulty)
+		get()._saveJs->j("state").u("life") = difficulty;
+}
+
+/**
+ * @brief Get difficulty of the game.
+ *
+ * @return uint difficulty (lower is more difficult)
+ */
+uint	Save::getDifficulty() {
+	return get()._saveJs->u("difficulty");
 }
 
 /**
@@ -408,7 +427,6 @@ bool	Save::_save(bool temporary) {
 		file::rm(_getFilename(true), true);
 		_saved = true;
 	}
-
 	return true;
 }
 

--- a/srcs/scenes/SceneDifficulty.cpp
+++ b/srcs/scenes/SceneDifficulty.cpp
@@ -134,7 +134,7 @@ void		SceneDifficulty::_updateUI() {
 	allUI.medium->setPos(tmpPos).setSize(tmpSize);
 	tmpPos.y -= menuHeight * 1.3;
 	allUI.hardCore->setPos(tmpPos).setSize(tmpSize);
-	tmpPos.y -= menuHeight * 1.3;
+	tmpPos.y -= menuHeight * 1.8;
 	allUI.menu->setPos(tmpPos).setSize(tmpSize);
 	tmpSize.x = tmpSize.x * 1.3;
 	tmpSize.y = winSz.y - tmpPos.y;

--- a/srcs/scenes/SceneDifficulty.cpp
+++ b/srcs/scenes/SceneDifficulty.cpp
@@ -90,16 +90,19 @@ bool	SceneDifficulty::update() {
 	if (_states.easy) {
 		_states.easy = false;
 		Save::newGame();
+		Save::setDifficulty(3);
 		SceneManager::loadScene(SceneNames::LEVEL_SELECTION);
 	}
 	else if (_states.medium) {
 		_states.medium = false;
 		Save::newGame();
+		Save::setDifficulty(2);
 		SceneManager::loadScene(SceneNames::LEVEL_SELECTION);
 	}
 	else if (_states.hardCore) {
 		_states.hardCore = false;
 		Save::newGame();
+		Save::setDifficulty(1);
 		SceneManager::loadScene(SceneNames::LEVEL_SELECTION);
 	}
 	else if (_states.menu || Inputs::getKeyUp(InputType::CANCEL)) {

--- a/srcs/scenes/SceneDifficulty.cpp
+++ b/srcs/scenes/SceneDifficulty.cpp
@@ -37,6 +37,9 @@ bool			SceneDifficulty::init() {
 	float menuHeight = winSz.y / 14;
 
 	try {
+		addExitButton()
+			.addButtonLeftListener(&_states.menu);
+
 		tmpPos.x = (winSz.x / 2) - (menuWidth / 2);
 		tmpPos.y = winSz.y - menuHeight * 2;
 		tmpSize.x = menuWidth;
@@ -44,7 +47,7 @@ bool			SceneDifficulty::init() {
 		addTitle(tmpPos, tmpSize, "Game mode");
 
 		allUI.beginner = &addButton(VOID_SIZE, VOID_SIZE, "beginner")
-			.setKeyLeftClickScancode(SDL_SCANCODE_1)
+			.setKeyLeftClickScancode(SDL_SCANCODE_0)
 			.addButtonLeftListener(&_states.beginner);
 		allUI.easy = &addButton(VOID_SIZE, VOID_SIZE, "easy")
 			.setKeyLeftClickScancode(SDL_SCANCODE_1)
@@ -55,9 +58,6 @@ bool			SceneDifficulty::init() {
 		allUI.hardCore = &addButton(VOID_SIZE, VOID_SIZE, "hard core")
 			.setKeyLeftClickScancode(SDL_SCANCODE_3)
 			.addButtonLeftListener(&_states.hardCore);
-		allUI.menu = &addButton(VOID_SIZE, VOID_SIZE, "main menu")
-			.setKeyLeftClickInput(InputType::GOTO_MENU)
-			.addButtonLeftListener(&_states.menu);
 
 		allUI.border = &addRect(VOID_SIZE, VOID_SIZE);
 
@@ -141,8 +141,6 @@ void		SceneDifficulty::_updateUI() {
 	allUI.medium->setPos(tmpPos).setSize(tmpSize);
 	tmpPos.y -= menuHeight * 1.3;
 	allUI.hardCore->setPos(tmpPos).setSize(tmpSize);
-	tmpPos.y -= menuHeight * 1.8;
-	allUI.menu->setPos(tmpPos).setSize(tmpSize);
 	tmpSize.x = tmpSize.x * 1.3;
 	tmpSize.y = winSz.y - tmpPos.y;
 	tmpPos.x = (winSz.x / 2) - ((menuWidth * 1.3) / 2);

--- a/srcs/scenes/SceneDifficulty.cpp
+++ b/srcs/scenes/SceneDifficulty.cpp
@@ -59,8 +59,8 @@ bool			SceneDifficulty::init() {
 		allUI.border = &addRect(VOID_SIZE, VOID_SIZE);
 
 
-		AudioManager::loadMusic("sounds/puzzle.ogg");
-		AudioManager::playMusic("sounds/puzzle.ogg", 0.1f, true);
+		AudioManager::loadMusic("sounds/menu_loop.ogg");
+		AudioManager::playMusic("sounds/menu_loop.ogg", 0.1f, true);
 
 		_initBG();
 	}

--- a/srcs/scenes/SceneDifficulty.cpp
+++ b/srcs/scenes/SceneDifficulty.cpp
@@ -1,0 +1,141 @@
+#include "SceneDifficulty.hpp"
+#include "AudioManager.hpp"
+#include "Save.hpp"
+
+SceneDifficulty::SceneDifficulty(Gui * gui, float const &dtTime)
+: ASceneMenu(gui, dtTime)
+{}
+
+SceneDifficulty::SceneDifficulty(SceneDifficulty const & src)
+: ASceneMenu(src)
+{
+	*this = src;
+}
+
+SceneDifficulty::~SceneDifficulty() {}
+
+SceneDifficulty & SceneDifficulty::operator=(SceneDifficulty const & rhs) {
+	if (this != &rhs) {
+		logWarn("you are copying SceneDifficulty")
+	}
+	return *this;
+}
+
+// - AScene Public Methods -----------------------------------------------------
+
+/**
+ * @brief init the menu
+ *
+ * @return true if the init succeed
+ * @return false if the init failed
+ */
+bool			SceneDifficulty::init() {
+	glm::vec2 winSz = _gui->gameInfo.windowSize;
+	glm::vec2 tmpPos;
+	glm::vec2 tmpSize;
+	float menuWidth = winSz.x / 2;
+	float menuHeight = winSz.y / 14;
+
+	try {
+		tmpPos.x = (winSz.x / 2) - (menuWidth / 2);
+		tmpPos.y = winSz.y - menuHeight * 2;
+		tmpSize.x = menuWidth;
+		tmpSize.y = menuHeight;
+		addTitle(tmpPos, tmpSize, "Game mode");
+
+		allUI.easy = &addButton(VOID_SIZE, VOID_SIZE, "easy")
+			.setKeyLeftClickScancode(SDL_SCANCODE_1)
+			.addButtonLeftListener(&_states.easy);
+		allUI.medium = &addButton(VOID_SIZE, VOID_SIZE, "medium")
+			.setKeyLeftClickScancode(SDL_SCANCODE_2)
+			.addButtonLeftListener(&_states.medium);
+		allUI.hardCore = &addButton(VOID_SIZE, VOID_SIZE, "hard core")
+			.setKeyLeftClickScancode(SDL_SCANCODE_3)
+			.addButtonLeftListener(&_states.hardCore);
+		allUI.menu = &addButton(VOID_SIZE, VOID_SIZE, "main menu")
+			.setKeyLeftClickInput(InputType::GOTO_MENU)
+			.addButtonLeftListener(&_states.menu);
+
+		allUI.border = &addRect(VOID_SIZE, VOID_SIZE);
+
+
+		AudioManager::loadMusic("sounds/puzzle.ogg");
+		AudioManager::playMusic("sounds/puzzle.ogg", 0.1f, true);
+
+		_initBG();
+	}
+	catch (ABaseUI::UIException const & e) {
+		logErr(e.what());
+		return false;
+	}
+	return true;
+}
+
+/**
+ * @brief called when the scene is loaded
+ */
+void SceneDifficulty::load() {
+	ASceneMenu::load();
+	_updateUI();
+}
+
+/**
+ * @brief this is the update function (called every frames)
+ *
+ * @return true if the update is a success
+ * @return false if there are an error in update
+ */
+bool	SceneDifficulty::update() {
+	ASceneMenu::update();
+	if (_states.easy) {
+		_states.easy = false;
+		Save::newGame();
+		SceneManager::loadScene(SceneNames::LEVEL_SELECTION);
+	}
+	else if (_states.medium) {
+		_states.medium = false;
+		Save::newGame();
+		SceneManager::loadScene(SceneNames::LEVEL_SELECTION);
+	}
+	else if (_states.hardCore) {
+		_states.hardCore = false;
+		Save::newGame();
+		SceneManager::loadScene(SceneNames::LEVEL_SELECTION);
+	}
+	else if (_states.menu || Inputs::getKeyUp(InputType::CANCEL)) {
+		_states.menu = false;
+		SceneManager::loadScene(SceneNames::MAIN_MENU);
+	}
+	return true;
+}
+
+// -- Private methods ----------------------------------------------------------
+
+/**
+ * @brief Update UI objects.
+ *
+ */
+void		SceneDifficulty::_updateUI() {
+	glm::vec2 winSz = _gui->gameInfo.windowSize;
+	glm::vec2 tmpPos;
+	glm::vec2 tmpSize;
+	float menuWidth = winSz.x / 2;
+	float menuHeight = winSz.y / 14;
+	tmpPos.x = (winSz.x / 2) - (menuWidth / 2);
+		tmpPos.y = winSz.y - menuHeight * 2;
+		tmpSize.x = menuWidth;
+		tmpSize.y = menuHeight;
+	tmpPos.y -= menuHeight * 1.8;
+	allUI.easy->setPos(tmpPos).setSize(tmpSize);
+	tmpPos.y -= menuHeight * 1.3;
+	allUI.medium->setPos(tmpPos).setSize(tmpSize);
+	tmpPos.y -= menuHeight * 1.3;
+	allUI.hardCore->setPos(tmpPos).setSize(tmpSize);
+	tmpPos.y -= menuHeight * 1.3;
+	allUI.menu->setPos(tmpPos).setSize(tmpSize);
+	tmpSize.x = tmpSize.x * 1.3;
+	tmpSize.y = winSz.y - tmpPos.y;
+	tmpPos.x = (winSz.x / 2) - ((menuWidth * 1.3) / 2);
+	tmpPos.y -= menuHeight * 0.5;
+	allUI.border->setPos(tmpPos).setSize(tmpSize);
+}

--- a/srcs/scenes/SceneDifficulty.cpp
+++ b/srcs/scenes/SceneDifficulty.cpp
@@ -58,10 +58,6 @@ bool			SceneDifficulty::init() {
 
 		allUI.border = &addRect(VOID_SIZE, VOID_SIZE);
 
-
-		AudioManager::loadMusic("sounds/menu_loop.ogg");
-		AudioManager::playMusic("sounds/menu_loop.ogg", 0.1f, true);
-
 		_initBG();
 	}
 	catch (ABaseUI::UIException const & e) {

--- a/srcs/scenes/SceneDifficulty.cpp
+++ b/srcs/scenes/SceneDifficulty.cpp
@@ -43,6 +43,9 @@ bool			SceneDifficulty::init() {
 		tmpSize.y = menuHeight;
 		addTitle(tmpPos, tmpSize, "Game mode");
 
+		allUI.beginner = &addButton(VOID_SIZE, VOID_SIZE, "beginner")
+			.setKeyLeftClickScancode(SDL_SCANCODE_1)
+			.addButtonLeftListener(&_states.beginner);
 		allUI.easy = &addButton(VOID_SIZE, VOID_SIZE, "easy")
 			.setKeyLeftClickScancode(SDL_SCANCODE_1)
 			.addButtonLeftListener(&_states.easy);
@@ -83,7 +86,13 @@ void SceneDifficulty::load() {
  */
 bool	SceneDifficulty::update() {
 	ASceneMenu::update();
-	if (_states.easy) {
+	if (_states.beginner) {
+		_states.beginner = false;
+		Save::newGame();
+		Save::setDifficulty(10);
+		SceneManager::loadScene(SceneNames::LEVEL_SELECTION);
+	}
+	else if (_states.easy) {
 		_states.easy = false;
 		Save::newGame();
 		Save::setDifficulty(3);
@@ -125,6 +134,8 @@ void		SceneDifficulty::_updateUI() {
 		tmpSize.x = menuWidth;
 		tmpSize.y = menuHeight;
 	tmpPos.y -= menuHeight * 1.8;
+	allUI.beginner->setPos(tmpPos).setSize(tmpSize);
+	tmpPos.y -= menuHeight * 1.3;
 	allUI.easy->setPos(tmpPos).setSize(tmpSize);
 	tmpPos.y -= menuHeight * 1.3;
 	allUI.medium->setPos(tmpPos).setSize(tmpSize);

--- a/srcs/scenes/SceneEndGame.cpp
+++ b/srcs/scenes/SceneEndGame.cpp
@@ -1,4 +1,5 @@
 #include "SceneEndGame.hpp"
+#include "AudioManager.hpp"
 #include "Save.hpp"
 
 SceneEndGame::SceneEndGame(Gui * gui, float const &dtTime)
@@ -97,6 +98,8 @@ bool			SceneEndGame::init() {
  */
 void SceneEndGame::load() {
 	ASceneMenu::load();
+	AudioManager::loadMusic("sounds/the_offspring-the_kids_arent_alright.ogg");
+	AudioManager::playMusic("sounds/the_offspring-the_kids_arent_alright.ogg", 0.3f, true);
 }
 
 /**
@@ -114,6 +117,7 @@ bool	SceneEndGame::update() {
 
 	if (_states.exit) {
 		_states.exit = false;
+		AudioManager::playMusic(MUSIC_MENU, 0.1f, true);
 		SceneManager::loadScene(SceneNames::MAIN_MENU);
 	}
 	return true;

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -391,7 +391,7 @@ bool	SceneGame::update() {
 		state = GameState::GAME_OVER;
 		return true;
 	}
-	if ((levelTime - time) < 20) {
+	if ((state != GameState::WIN || state != GameState::GAME_OVER) && (levelTime - time) < 20) {
 		if (!_alarm) {
 			try {
 				AudioManager::playSound(ALARM_TIME_SOUND);

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -577,7 +577,9 @@ bool	SceneGame::drawGame() {
 	_gui->textureManager->disableTextures();
 	_gui->cubeShader->unuse();
 
-	if (state == GameState::PLAY && allUI.timeLeftImg->getPos() != VOID_SIZE) {
+	if (state == GameState::PLAY
+		&& (allUI.timeLeftImg->getPos() != VOID_SIZE || allUI.timeLeftImgActive->getPos() != VOID_SIZE))
+	{
 		ASceneMenu::draw();
 	}
 	else if (state == GameState::INTRO) {
@@ -1218,24 +1220,40 @@ bool SceneGame::insertEntity(std::string const & name, glm::ivec2 pos, bool isFl
 void SceneGame::_initGameInfos() {
 	try {
 		allUI.timeLeftImg = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/time.png");
+		allUI.timeLeftImgActive = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/time_active.png");
 		allUI.timeLeftText = &addText(VOID_SIZE, VOID_SIZE, "time-left").setTextAlign(TextAlign::RIGHT);
 		allUI.scoreImg = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/score.png");
+		allUI.scoreImgActive = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/score_active.png");
 		allUI.scoreText = &addText(VOID_SIZE, VOID_SIZE, "score").setTextAlign(TextAlign::RIGHT);
 		allUI.lifeImg = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/life.png");
+		allUI.lifeImgActive = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/life_active.png");
 		allUI.lifeText = &addText(VOID_SIZE, VOID_SIZE, "nb-player-lives").setTextAlign(TextAlign::RIGHT);
 		allUI.levelNameText = &addText(VOID_SIZE, VOID_SIZE, "level-name").setTextAlign(TextAlign::RIGHT);
 		allUI.enemiesCounterText = &addText(VOID_SIZE, VOID_SIZE, "nb-enemies").setTextAlign(TextAlign::RIGHT);
 		allUI.speedImg = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/speed.png");
+		allUI.speedImgActive = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/speed_active.png");
 		allUI.speedText = &addText(VOID_SIZE, VOID_SIZE, "speed").setTextAlign(TextAlign::RIGHT);
 		allUI.bonusBombImg = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/bomb.png");
+		allUI.bonusBombImgActive = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/bomb_active.png");
 		allUI.bonusBombText = &addText(VOID_SIZE, VOID_SIZE, "total-bombs").setTextAlign(TextAlign::RIGHT);
 		allUI.bonusFlameImg = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/flame.png");
+		allUI.bonusFlameImgActive = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/flame_active.png");
 		allUI.bonusFlameText = &addText(VOID_SIZE, VOID_SIZE, "bomb-propagation").setTextAlign(TextAlign::RIGHT);
 		allUI.bonusFlampassImg = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/flampass.png");
+		allUI.bonusFlampassImgActive = &addImage(VOID_SIZE, VOID_SIZE,
+			"bomberman-assets/textures/bonus/flampass_active.png");
 		allUI.bonusWallpassImg = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/wallpass.png");
+		allUI.bonusWallpassImgActive = &addImage(VOID_SIZE, VOID_SIZE,
+			"bomberman-assets/textures/bonus/wallpass_active.png");
 		allUI.bonusDetonatorImg = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/detonator.png");
+		allUI.bonusDetonatorImgActive = &addImage(VOID_SIZE, VOID_SIZE,
+			"bomberman-assets/textures/bonus/detonator_active.png");
 		allUI.bonusBombpassImg = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/bombpass.png");
+		allUI.bonusBombpassImgActive = &addImage(VOID_SIZE, VOID_SIZE,
+			"bomberman-assets/textures/bonus/bombpass_active.png");
 		allUI.bonusShieldImg = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/shield.png");
+		allUI.bonusShieldImgActive = &addImage(VOID_SIZE, VOID_SIZE,
+			"bomberman-assets/textures/bonus/shield_active.png");
 		allUI.bonusShieldText = &addText(VOID_SIZE, VOID_SIZE, "invulnerable").setTextAlign(TextAlign::RIGHT);
 	} catch (ABaseUI::UIException const & e) {
 		logErr(e.what());
@@ -1248,24 +1266,35 @@ void SceneGame::_initGameInfos() {
 void		SceneGame::_loadGameInfos() {
 	try {
 		allUI.timeLeftImg->setPos(VOID_SIZE).setSize(VOID_SIZE);
+		allUI.timeLeftImgActive->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.timeLeftText->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.scoreImg->setPos(VOID_SIZE).setSize(VOID_SIZE);
+		allUI.scoreImgActive->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.scoreText->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.lifeImg->setPos(VOID_SIZE).setSize(VOID_SIZE);
+		allUI.lifeImgActive->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.lifeText->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.levelNameText->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.enemiesCounterText->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.speedImg->setPos(VOID_SIZE).setSize(VOID_SIZE);
+		allUI.speedImgActive->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.speedText->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.bonusBombImg->setPos(VOID_SIZE).setSize(VOID_SIZE);
+		allUI.bonusBombImgActive->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.bonusBombText->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.bonusFlameImg->setPos(VOID_SIZE).setSize(VOID_SIZE);
+		allUI.bonusFlameImgActive->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.bonusFlameText->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.bonusFlampassImg->setPos(VOID_SIZE).setSize(VOID_SIZE);
+		allUI.bonusFlampassImgActive->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.bonusWallpassImg->setPos(VOID_SIZE).setSize(VOID_SIZE);
+		allUI.bonusWallpassImgActive->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.bonusDetonatorImg->setPos(VOID_SIZE).setSize(VOID_SIZE);
+		allUI.bonusDetonatorImgActive->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.bonusBombpassImg->setPos(VOID_SIZE).setSize(VOID_SIZE);
+		allUI.bonusBombpassImgActive->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.bonusShieldImg->setPos(VOID_SIZE).setSize(VOID_SIZE);
+		allUI.bonusShieldImgActive->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.bonusShieldText->setPos(VOID_SIZE).setSize(VOID_SIZE);
 	} catch (ABaseUI::UIException const & e) {
 		logErr(e.what());
@@ -1305,8 +1334,16 @@ void			SceneGame::_updateGameInfos() {
 
 		// -- Top -----------
 		/* time left */
-		allUI.timeLeftImg->setPos({tmpPos.x, imgY}).setSize(tmpSize);
-		tmpPos.x += allUI.timeLeftImg->getSize().x;
+		if (player->bonusActifs.time > 0) {
+			allUI.timeLeftImgActive->setPos({tmpPos.x, imgY}).setSize(tmpSize);
+			allUI.timeLeftImg->setPos(VOID_POS).setSize(VOID_SIZE);
+			tmpPos.x += allUI.timeLeftImgActive->getSize().x;
+		}
+		else {
+			allUI.timeLeftImg->setPos({tmpPos.x, imgY}).setSize(tmpSize);
+			allUI.timeLeftImgActive->setPos(VOID_POS).setSize(VOID_SIZE);
+			tmpPos.x += allUI.timeLeftImg->getSize().x;
+		}
 		allUI.timeLeftText->setPos({tmpPos.x, textY}).setText(timeToString(levelTime - time))
 			.setSize(VOID_POS).setCalculatedSize();
 		if (!_alarm)
@@ -1317,8 +1354,16 @@ void			SceneGame::_updateGameInfos() {
 
 		/* life */
 		tmpPos.x += padding;
-		allUI.lifeImg->setPos({tmpPos.x, imgY}).setSize(tmpSize);
-		tmpPos.x += allUI.lifeImg->getSize().x;
+		if (player->bonusActifs.life > 0) {
+			allUI.lifeImgActive->setPos({tmpPos.x, imgY}).setSize(tmpSize);
+			allUI.lifeImg->setPos(VOID_POS).setSize(VOID_SIZE);
+			tmpPos.x += allUI.lifeImgActive->getSize().x;
+		}
+		else {
+			allUI.lifeImg->setPos({tmpPos.x, imgY}).setSize(tmpSize);
+			allUI.lifeImgActive->setPos(VOID_POS).setSize(VOID_SIZE);
+			tmpPos.x += allUI.lifeImg->getSize().x;
+		}
 		allUI.lifeText->setPos({tmpPos.x, textY}).setText(std::to_string(player->lives))
 			.setSize(VOID_SIZE).setCalculatedSize();
 		tmpPos.x += allUI.lifeText->getSize().x;
@@ -1340,9 +1385,18 @@ void			SceneGame::_updateGameInfos() {
 		allUI.scoreText->setText(score.toString()).setSize(VOID_POS).setCalculatedSize();
 		tmpPos.x -= allUI.scoreText->getSize().x;
 		allUI.scoreText->setPos({tmpPos.x, textY});
-		allUI.scoreImg->setSize(tmpSize);
-		tmpPos.x -= allUI.scoreImg->getSize().x;
-		allUI.scoreImg->setPos({tmpPos.x, imgY});
+		if (player->bonusActifs.score > 0) {
+			allUI.scoreImgActive->setSize(tmpSize);
+			tmpPos.x -= allUI.scoreImgActive->getSize().x;
+			allUI.scoreImgActive->setPos({tmpPos.x, imgY});
+			allUI.scoreImg->setPos(VOID_POS).setSize(VOID_SIZE);
+		}
+		else {
+			allUI.scoreImg->setSize(tmpSize);
+			tmpPos.x -= allUI.scoreImg->getSize().x;
+			allUI.scoreImg->setPos({tmpPos.x, imgY});
+			allUI.scoreImgActive->setPos(VOID_POS).setSize(VOID_SIZE);
+		}
 
 		// -- Bonus -----------
 		glm::vec2 pos = {winSz.x / 10, winSz.y - menuHeight * 4};
@@ -1350,8 +1404,16 @@ void			SceneGame::_updateGameInfos() {
 
 		/* speed */
 		// tmpPos.x += padding;
-		allUI.speedImg->setPos(tmpPos).setSize(tmpSize);
-		tmpPos.x += allUI.speedImg->getSize().x;
+		if (player->bonusActifs.speed > 0) {
+			allUI.speedImgActive->setPos(tmpPos).setSize(tmpSize);
+			allUI.speedImg->setPos(VOID_POS).setSize(VOID_SIZE);
+			tmpPos.x += allUI.speedImgActive->getSize().x;
+		}
+		else {
+			allUI.speedImg->setPos(tmpPos).setSize(tmpSize);
+			allUI.speedImgActive->setPos(VOID_POS).setSize(VOID_SIZE);
+			tmpPos.x += allUI.speedImg->getSize().x;
+		}
 		std::string	speed = std::to_string(player->speed);
 		speed = speed.substr(0, speed.find("."));
 		allUI.speedText->setPos({tmpPos.x, tmpPos.y + 2}).setText(speed)
@@ -1360,16 +1422,32 @@ void			SceneGame::_updateGameInfos() {
 		tmpPos = pos;
 
 		/* bonus bomb */
-		allUI.bonusBombImg->setPos(tmpPos).setSize(tmpSize);
-		tmpPos.x += allUI.bonusBombImg->getSize().x;
+		if (player->bonusActifs.bombs > 0) {
+			allUI.bonusBombImgActive->setPos(tmpPos).setSize(tmpSize);
+			allUI.bonusBombImg->setPos(VOID_POS).setSize(VOID_SIZE);
+			tmpPos.x += allUI.bonusBombImgActive->getSize().x;
+		}
+		else {
+			allUI.bonusBombImg->setPos(tmpPos).setSize(tmpSize);
+			allUI.bonusBombImgActive->setPos(VOID_POS).setSize(VOID_SIZE);
+			tmpPos.x += allUI.bonusBombImg->getSize().x;
+		}
 		allUI.bonusBombText->setPos({tmpPos.x, tmpPos.y + 2}).setText(std::to_string(player->totalBombs))
 			.setSize(VOID_SIZE).setCalculatedSize();
 		pos.y -= menuHeight * 0.8;
 		tmpPos = pos;
 
 		/* bonus flame */
-		allUI.bonusFlameImg->setPos(tmpPos).setSize(tmpSize);
-		tmpPos.x += allUI.bonusFlameImg->getSize().x;
+		if (player->bonusActifs.flames > 0) {
+			allUI.bonusFlameImgActive->setPos(tmpPos).setSize(tmpSize);
+			allUI.bonusFlameImg->setPos(VOID_POS).setSize(VOID_SIZE);
+			tmpPos.x += allUI.bonusFlameImgActive->getSize().x;
+		}
+		else {
+			allUI.bonusFlameImg->setPos(tmpPos).setSize(tmpSize);
+			allUI.bonusFlameImgActive->setPos(VOID_POS).setSize(VOID_SIZE);
+			tmpPos.x += allUI.bonusFlameImg->getSize().x;
+		}
 		allUI.bonusFlameText->setPos({tmpPos.x, tmpPos.y + 2}).setText(std::to_string(player->bombProgation))
 			.setSize(VOID_SIZE).setCalculatedSize();
 		pos.y -= menuHeight * 0.8;
@@ -1377,7 +1455,14 @@ void			SceneGame::_updateGameInfos() {
 
 		/* bonus flampass */
 		if (player->passFire) {
-			allUI.bonusFlampassImg->setPos(tmpPos).setSize(tmpSize);
+			if (player->bonusActifs.flampass > 0) {
+				allUI.bonusFlampassImgActive->setPos(tmpPos).setSize(tmpSize);
+				allUI.bonusFlampassImg->setPos(VOID_POS).setSize(VOID_SIZE);
+			}
+			else {
+				allUI.bonusFlampassImg->setPos(tmpPos).setSize(tmpSize);
+				allUI.bonusFlampassImgActive->setPos(VOID_POS).setSize(VOID_SIZE);
+			}
 			pos.y -= menuHeight * 0.8;
 			tmpPos = pos;
 		} else {
@@ -1385,7 +1470,14 @@ void			SceneGame::_updateGameInfos() {
 		}
 		/* bonus wallpass */
 		if (player->passWall) {
-			allUI.bonusWallpassImg->setPos(tmpPos).setSize(tmpSize);
+			if (player->bonusActifs.wallpass > 0) {
+				allUI.bonusWallpassImgActive->setPos(tmpPos).setSize(tmpSize);
+				allUI.bonusWallpassImg->setPos(VOID_POS).setSize(VOID_SIZE);
+			}
+			else {
+				allUI.bonusWallpassImg->setPos(tmpPos).setSize(tmpSize);
+				allUI.bonusWallpassImgActive->setPos(VOID_POS).setSize(VOID_SIZE);
+			}
 			pos.y -= menuHeight * 0.8;
 			tmpPos = pos;
 		} else {
@@ -1393,7 +1485,14 @@ void			SceneGame::_updateGameInfos() {
 		}
 		/* bonus detonator */
 		if (player->detonator) {
-			allUI.bonusDetonatorImg->setPos(tmpPos).setSize(tmpSize);
+			if (player->bonusActifs.detonator > 0) {
+				allUI.bonusDetonatorImgActive->setPos(tmpPos).setSize(tmpSize);
+				allUI.bonusDetonatorImg->setPos(VOID_POS).setSize(VOID_SIZE);
+			}
+			else {
+				allUI.bonusDetonatorImg->setPos(tmpPos).setSize(tmpSize);
+				allUI.bonusDetonatorImgActive->setPos(VOID_POS).setSize(VOID_SIZE);
+			}
 			pos.y -= menuHeight * 0.8;
 			tmpPos = pos;
 		} else {
@@ -1401,7 +1500,14 @@ void			SceneGame::_updateGameInfos() {
 		}
 		/* bonus passBomb */
 		if (player->passBomb) {
-			allUI.bonusBombpassImg->setPos(tmpPos).setSize(tmpSize);
+			if (player->bonusActifs.bombpass > 0) {
+				allUI.bonusBombpassImgActive->setPos(tmpPos).setSize(tmpSize);
+				allUI.bonusBombpassImg->setPos(VOID_POS).setSize(VOID_SIZE);
+			}
+			else {
+				allUI.bonusBombpassImg->setPos(tmpPos).setSize(tmpSize);
+				allUI.bonusBombpassImgActive->setPos(VOID_POS).setSize(VOID_SIZE);
+			}
 			pos.y -= menuHeight * 0.8;
 			tmpPos = pos;
 		} else {
@@ -1409,8 +1515,16 @@ void			SceneGame::_updateGameInfos() {
 		}
 		/* bonus invulnerable */
 		if (player->invulnerable) {
-			allUI.bonusShieldImg->setPos(tmpPos).setSize(tmpSize);
-			tmpPos.x += allUI.bonusShieldImg->getSize().x;
+			if (player->bonusActifs.shield > 0) {
+				allUI.bonusShieldImgActive->setPos(tmpPos).setSize(tmpSize);
+				allUI.bonusShieldImg->setPos(VOID_POS).setSize(VOID_SIZE);
+				tmpPos.x += allUI.bonusShieldImgActive->getSize().x;
+			}
+			else {
+				allUI.bonusShieldImg->setPos(tmpPos).setSize(tmpSize);
+				allUI.bonusShieldImgActive->setPos(VOID_POS).setSize(VOID_SIZE);
+				tmpPos.x += allUI.bonusShieldImg->getSize().x;
+			}
 			std::string	invulnerable = std::to_string(player->invulnerable);
 			invulnerable = invulnerable.substr(0, invulnerable.find(".")+2);
 			allUI.bonusShieldText->setPos({tmpPos.x, tmpPos.y + 2}).setText(timeToString(player->invulnerable))

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -861,7 +861,7 @@ bool	SceneGame::_initJsonLevel(int32_t levelId) {
 	lvl->add<SettingsJson>("bonus");
 		for (auto &&pair : Bonus::bonus) {
 			lvl->j("bonus").add<SettingsJson>(pair.first);
-			lvl->j("bonus").j(pair.first).add<int64_t>("chance", 0).setMin(0).setMax(25);
+			lvl->j("bonus").j(pair.first).add<int64_t>("chance", 0).setMin(0).setMax(100);
 			lvl->j("bonus").j(pair.first).add<int64_t>("nb", -1).setMin(-1).setMax(100);
 		}
 	try {

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -293,7 +293,7 @@ bool	SceneGame::update() {
 			if (Inputs::getKeyUp(InputType::CONFIRM))
 				AudioManager::stopSound(INTROLEVEL_SOUND);
 			_gui->cam->setMode(CamMode::STATIC_DEFPOS);
-			AudioManager::resumeMusic();
+			AudioManager::playMusic(musicLevel, 0.3f, true);
 			state = GameState::PLAY;
 		}
 		return true;

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -1187,6 +1187,7 @@ void SceneGame::_initGameInfos() {
 		allUI.scoreText = &addText(VOID_SIZE, VOID_SIZE, "score").setTextAlign(TextAlign::RIGHT);
 		allUI.lifeImg = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/life.png");
 		allUI.lifeText = &addText(VOID_SIZE, VOID_SIZE, "nb-player-lives").setTextAlign(TextAlign::RIGHT);
+		allUI.levelNameText = &addText(VOID_SIZE, VOID_SIZE, "level-name").setTextAlign(TextAlign::RIGHT);
 		allUI.enemiesCounterText = &addText(VOID_SIZE, VOID_SIZE, "nb-enemies").setTextAlign(TextAlign::RIGHT);
 		allUI.speedImg = &addImage(VOID_SIZE, VOID_SIZE, "bomberman-assets/textures/bonus/speed.png");
 		allUI.speedText = &addText(VOID_SIZE, VOID_SIZE, "speed").setTextAlign(TextAlign::RIGHT);
@@ -1216,6 +1217,7 @@ void		SceneGame::_loadGameInfos() {
 		allUI.scoreText->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.lifeImg->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.lifeText->setPos(VOID_SIZE).setSize(VOID_SIZE);
+		allUI.levelNameText->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.enemiesCounterText->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.speedImg->setPos(VOID_SIZE).setSize(VOID_SIZE);
 		allUI.speedText->setPos(VOID_SIZE).setSize(VOID_SIZE);
@@ -1256,6 +1258,15 @@ void			SceneGame::_updateGameInfos() {
 		tmpSize.y = menuHeight;
 		tmpSize = {32, 32};
 
+		// -- Title ---------
+		/* level name */
+		allUI.levelNameText->setText(getLevelName(level))
+			.setSize(VOID_POS).setCalculatedSize();
+		allUI.levelNameText->setPos({(winSz.x / 2) - allUI.levelNameText->getSize().x / 2, tmpPos.y + 1.5 * tmpSize.y});
+
+		tmpPos.x = (winSz.x / 2) - (menuWidth / 2);
+		tmpPos.y = winSz.y - menuHeight * 2;
+
 		// -- Top -----------
 		/* time left */
 		allUI.timeLeftImg->setPos({tmpPos.x, imgY}).setSize(tmpSize);
@@ -1276,14 +1287,6 @@ void			SceneGame::_updateGameInfos() {
 			.setSize(VOID_SIZE).setCalculatedSize();
 		tmpPos.x += allUI.lifeText->getSize().x;
 
-		/* score */
-		tmpPos.x += padding;
-		allUI.scoreImg->setPos({tmpPos.x, imgY}).setSize(tmpSize);
-		tmpPos.x += allUI.scoreImg->getSize().x;
-		allUI.scoreText->setPos({tmpPos.x, textY}).setText(score.toString())
-			.setSize(VOID_POS).setCalculatedSize();
-		tmpPos.x += allUI.scoreText->getSize().x;
-
 		/* enemies counter */
 		if (enemiesToKill > 0) {
 			tmpPos.x += padding;
@@ -1295,6 +1298,15 @@ void			SceneGame::_updateGameInfos() {
 				.setSize(VOID_POS).setCalculatedSize().setTextColor(color);
 			tmpPos.x += allUI.enemiesCounterText->getSize().x;
 		}
+
+		/* score */
+		tmpPos.x = (winSz.x / 2) + (menuWidth / 2);
+		allUI.scoreText->setText(score.toString()).setSize(VOID_POS).setCalculatedSize();
+		tmpPos.x -= allUI.scoreText->getSize().x;
+		allUI.scoreText->setPos({tmpPos.x, textY});
+		allUI.scoreImg->setSize(tmpSize);
+		tmpPos.x -= allUI.scoreImg->getSize().x;
+		allUI.scoreImg->setPos({tmpPos.x, imgY});
 
 		// -- Bottom -----------
 		tmpPos.x = (winSz.x / 2) - (menuWidth / 2);

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -877,6 +877,12 @@ bool	SceneGame::_initJsonLevel(int32_t levelId) {
 	return true;
 }
 
+/**
+ * @brief Unload data of level.
+ *
+ * @return true if succeed
+ * @return false
+ */
 bool	SceneGame::_unloadLevel() {
 	if (level == NO_LEVEL)
 		return true;
@@ -913,6 +919,19 @@ bool	SceneGame::_unloadLevel() {
 	}
 	enemies.clear();
 
+	for (auto spawner : spawners) {
+		delete spawner;
+	}
+	spawners.clear();
+
+	// Delete old player
+	delete player;
+	player = nullptr;
+
+	// spawners
+	enemiesToKill = 0;
+	enemiesKilled = 0;
+
 	level = NO_LEVEL;
 	return true;
 }
@@ -931,13 +950,6 @@ bool	SceneGame::_loadLevel(int32_t levelId) {
 		logErr("unable to load level " << levelId << ": doesn't exist");
 		return false;
 	}
-
-	// Delete old player
-	delete player;
-	player = nullptr;
-
-	enemiesToKill = 0;
-	enemiesKilled = 0;
 
 	level = levelId;  // save new level ID
 	SettingsJson & lvl = *(_mapsList[level]);

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -794,7 +794,9 @@ bool SceneGame::loadLevel(int32_t levelId) {
 
 bool	SceneGame::_initJsonLevel(int32_t levelId) {
 	// level$(levelID)
-	std::string		levelName = "level" + std::to_string(levelId);
+	std::stringstream ss;
+	ss << "level" << std::setw(2) << std::setfill('0') << levelId;
+	std::string		levelName = ss.str();
 	// $(mapsPath)/$(levelName).json
 	std::string		filename = s.s("mapsPath") + "/" + levelName + ".json";
 	if (file::isFile(filename) == false) {

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -1424,6 +1424,8 @@ uint32_t	SceneGame::getNbLevel() const { return _mapsList.size(); }
 std::string	SceneGame::getLevelName(int32_t levelId) const {
 	if (levelId == NO_LEVEL)
 		return "NO_LEVEL";
+	if (static_cast<int32_t>(_mapsList.size()) <= levelId)
+		throw SceneGameException(("Level " + std::to_string(levelId) + " do not exist.").c_str());
 	return _mapsList[levelId]->s("name");
 }
 std::string	SceneGame::getLevelImg(int32_t levelId) const {

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -387,7 +387,7 @@ bool	SceneGame::update() {
 	}
 
 	time += _dtTime;
-	if ((levelTime - time) < 0) {
+	if ((state != GameState::WIN || state != GameState::GAME_OVER) && (levelTime - time) < 0) {
 		state = GameState::GAME_OVER;
 		return true;
 	}

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -341,7 +341,7 @@ bool	SceneGame::update() {
 			Save::save(true);
 			AudioManager::stopAllSounds();
 			try {
-				AudioManager::playSound(WIN_SOUND, 1.0f, false, true);
+				AudioManager::playSound(WIN_SOUND, 1.0f, false, true, 2000);
 			} catch(Sound::SoundException const & e) {
 				logErr(e.what());
 			}
@@ -363,7 +363,7 @@ bool	SceneGame::update() {
 		if (_gui->cam->getMode() != CamMode::FOLLOW_PATH) {
 			AudioManager::stopAllSounds();
 			try {
-				AudioManager::playSound(GAME_OVER_SOUND, 1.0f, false, true);
+				AudioManager::playSound(GAME_OVER_SOUND, 1.0f, false, true, 2000);
 			} catch(Sound::SoundException const & e) {
 				logErr(e.what());
 			}
@@ -723,7 +723,7 @@ void SceneGame::load() {
 	if (_gui->cam->getMode() == CamMode::FOLLOW_PATH) {
 		state = GameState::INTRO;
 		try {
-			AudioManager::playSound(INTROLEVEL_SOUND);
+			AudioManager::playSound(INTROLEVEL_SOUND, 1.0f, false, false, 2000);
 		} catch(Sound::SoundException const & e) {
 			logErr(e.what());
 		}

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -321,20 +321,6 @@ bool	SceneGame::update() {
 	}
 	else if (state == GameState::WIN) {
 		if (_gui->cam->getMode() != CamMode::FOLLOW_PATH) {
-			AudioManager::stopAllSounds();
-			try {
-				AudioManager::playSound(WIN_SOUND, 1.0f, false, true);
-			} catch(Sound::SoundException const & e) {
-				logErr(e.what());
-			}
-			_gui->cam->setMode(CamMode::FOLLOW_PATH);
-			_gui->cam->setFollowPath(_getGameOverAnim());
-			for (auto &&enemy : enemies) {
-				enemy->setState(EntityState::IDLE);
-				enemy->update();
-			}
-		}
-		if (_gui->cam->isFollowFinished() || Inputs::getKeyUp(InputType::CONFIRM)) {
 			int32_t	crispiesLast = 0;
 			for (auto &&box : board) {
 				for (auto &&row : box) {
@@ -353,6 +339,20 @@ bool	SceneGame::update() {
 			score.addBonusEnemies(levelEnemies, remainEnemies, levelCrispies, crispiesLast);
 			Save::updateSavedFile(*this, true);
 			Save::save(true);
+			AudioManager::stopAllSounds();
+			try {
+				AudioManager::playSound(WIN_SOUND, 1.0f, false, true);
+			} catch(Sound::SoundException const & e) {
+				logErr(e.what());
+			}
+			_gui->cam->setMode(CamMode::FOLLOW_PATH);
+			_gui->cam->setFollowPath(_getGameOverAnim());
+			for (auto &&enemy : enemies) {
+				enemy->setState(EntityState::IDLE);
+				enemy->update();
+			}
+		}
+		if (_gui->cam->isFollowFinished() || Inputs::getKeyUp(InputType::CONFIRM)) {
 			delete player;
 			player = nullptr;
 			SceneManager::loadScene(SceneNames::VICTORY);

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -811,7 +811,7 @@ bool	SceneGame::_initJsonLevel(int32_t levelId) {
 	// File json definition:
 	lvl->add<std::string>("name");
 	lvl->add<std::string>("img", "bomberman-assets/img/icon_level1");
-	lvl->add<std::string>("music", "sounds/puzzle.ogg");
+	lvl->add<std::string>("music", "");
 	lvl->add<uint64_t>("height", 0).setMin(0).setMax(100);
 	lvl->add<uint64_t>("width", 0).setMin(0).setMax(100);
 	lvl->add<int64_t>("time", 0).setMin(-1).setMax(86400);
@@ -934,6 +934,7 @@ bool	SceneGame::_unloadLevel() {
 	// spawners
 	enemiesToKill = 0;
 	enemiesKilled = 0;
+	musicLevel = "";
 
 	level = NO_LEVEL;
 	return true;
@@ -972,6 +973,14 @@ bool	SceneGame::_loadLevel(int32_t levelId) {
 	levelTime = lvl.i("time");
 
 	enemiesToKill = lvl.i("enemiesToKill");
+
+	if (lvl.s("music").size()) {
+		musicLevel = lvl.s("music");
+	} else {
+		musicLevel = AudioManager::musics[rand() % AudioManager::musics.size()];
+	}
+
+	AudioManager::loadMusic(musicLevel);
 
 	flags = 0;
 	// Get map informations

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -811,6 +811,7 @@ bool	SceneGame::_initJsonLevel(int32_t levelId) {
 	// File json definition:
 	lvl->add<std::string>("name");
 	lvl->add<std::string>("img", "bomberman-assets/img/icon_level1");
+	lvl->add<std::string>("music", "sounds/puzzle.ogg");
 	lvl->add<uint64_t>("height", 0).setMin(0).setMax(100);
 	lvl->add<uint64_t>("width", 0).setMin(0).setMax(100);
 	lvl->add<int64_t>("time", 0).setMin(-1).setMax(86400);
@@ -1308,80 +1309,77 @@ void			SceneGame::_updateGameInfos() {
 		tmpPos.x -= allUI.scoreImg->getSize().x;
 		allUI.scoreImg->setPos({tmpPos.x, imgY});
 
-		// -- Bottom -----------
-		tmpPos.x = (winSz.x / 2) - (menuWidth / 2);
-		tmpPos.y = menuHeight;
-		imgY = tmpPos.y;
-		textY = tmpPos.y + 2;
+		// -- Bonus -----------
+		glm::vec2 pos = {winSz.x / 10, winSz.y - menuHeight * 4};
+		tmpPos = pos;
 
 		/* speed */
 		// tmpPos.x += padding;
-		allUI.speedImg->setPos({tmpPos.x, imgY}).setSize(tmpSize);
+		allUI.speedImg->setPos(tmpPos).setSize(tmpSize);
 		tmpPos.x += allUI.speedImg->getSize().x;
 		std::string	speed = std::to_string(player->speed);
 		speed = speed.substr(0, speed.find("."));
-		allUI.speedText->setPos({tmpPos.x, textY}).setText(speed)
+		allUI.speedText->setPos({tmpPos.x, tmpPos.y + 2}).setText(speed)
 			.setSize(VOID_SIZE).setCalculatedSize();
-		tmpPos.x += allUI.speedText->getSize().x;
+		pos.y -= menuHeight * 0.8;
+		tmpPos = pos;
 
 		/* bonus bomb */
-		tmpPos.x += padding;
-		allUI.bonusBombImg->setPos({tmpPos.x, imgY}).setSize(tmpSize);
+		allUI.bonusBombImg->setPos(tmpPos).setSize(tmpSize);
 		tmpPos.x += allUI.bonusBombImg->getSize().x;
-		allUI.bonusBombText->setPos({tmpPos.x, textY}).setText(std::to_string(player->totalBombs))
+		allUI.bonusBombText->setPos({tmpPos.x, tmpPos.y + 2}).setText(std::to_string(player->totalBombs))
 			.setSize(VOID_SIZE).setCalculatedSize();
-		tmpPos.x += allUI.bonusBombText->getSize().x;
+		pos.y -= menuHeight * 0.8;
+		tmpPos = pos;
 
 		/* bonus flame */
-		tmpPos.x += padding;
-		allUI.bonusFlameImg->setPos({tmpPos.x, imgY}).setSize(tmpSize);
+		allUI.bonusFlameImg->setPos(tmpPos).setSize(tmpSize);
 		tmpPos.x += allUI.bonusFlameImg->getSize().x;
-		allUI.bonusFlameText->setPos({tmpPos.x, textY}).setText(std::to_string(player->bombProgation))
+		allUI.bonusFlameText->setPos({tmpPos.x, tmpPos.y + 2}).setText(std::to_string(player->bombProgation))
 			.setSize(VOID_SIZE).setCalculatedSize();
-		tmpPos.x += allUI.bonusFlameText->getSize().x;
+		pos.y -= menuHeight * 0.8;
+		tmpPos = pos;
 
 		/* bonus flampass */
 		if (player->passFire) {
-			tmpPos.x += padding;
-			allUI.bonusFlampassImg->setPos({tmpPos.x, imgY}).setSize(tmpSize);
-			tmpPos.x += allUI.bonusFlampassImg->getSize().x;
+			allUI.bonusFlampassImg->setPos(tmpPos).setSize(tmpSize);
+			pos.y -= menuHeight * 0.8;
+			tmpPos = pos;
 		} else {
 			allUI.bonusFlampassImg->setPos(VOID_POS).setSize(VOID_SIZE);
 		}
 		/* bonus wallpass */
 		if (player->passWall) {
-			tmpPos.x += padding;
-			allUI.bonusWallpassImg->setPos({tmpPos.x, imgY}).setSize(tmpSize);
-			tmpPos.x += allUI.bonusWallpassImg->getSize().x;
+			allUI.bonusWallpassImg->setPos(tmpPos).setSize(tmpSize);
+			pos.y -= menuHeight * 0.8;
+			tmpPos = pos;
 		} else {
 			allUI.bonusWallpassImg->setPos(VOID_POS).setSize(VOID_SIZE);
 		}
 		/* bonus detonator */
 		if (player->detonator) {
-			tmpPos.x += padding;
-			allUI.bonusDetonatorImg->setPos({tmpPos.x, imgY}).setSize(tmpSize);
-			tmpPos.x += allUI.bonusDetonatorImg->getSize().x;
+			allUI.bonusDetonatorImg->setPos(tmpPos).setSize(tmpSize);
+			pos.y -= menuHeight * 0.8;
+			tmpPos = pos;
 		} else {
 			allUI.bonusDetonatorImg->setPos(VOID_POS).setSize(VOID_SIZE);
 		}
 		/* bonus passBomb */
 		if (player->passBomb) {
-			tmpPos.x += padding;
-			allUI.bonusBombpassImg->setPos({tmpPos.x, imgY}).setSize(tmpSize);
-			tmpPos.x += allUI.bonusBombpassImg->getSize().x;
+			allUI.bonusBombpassImg->setPos(tmpPos).setSize(tmpSize);
+			pos.y -= menuHeight * 0.8;
+			tmpPos = pos;
 		} else {
 			allUI.bonusBombpassImg->setPos(VOID_POS).setSize(VOID_SIZE);
 		}
 		/* bonus invulnerable */
 		if (player->invulnerable) {
-			tmpPos.x += padding;
-			allUI.bonusShieldImg->setPos({tmpPos.x, imgY}).setSize(tmpSize);
+			allUI.bonusShieldImg->setPos(tmpPos).setSize(tmpSize);
 			tmpPos.x += allUI.bonusShieldImg->getSize().x;
 			std::string	invulnerable = std::to_string(player->invulnerable);
 			invulnerable = invulnerable.substr(0, invulnerable.find(".")+2);
-			allUI.bonusShieldText->setPos({tmpPos.x, textY}).setText(timeToString(player->invulnerable))
+			allUI.bonusShieldText->setPos({tmpPos.x, tmpPos.y + 2}).setText(timeToString(player->invulnerable))
 				.setSize(VOID_SIZE).setCalculatedSize();
-			tmpPos.x += allUI.bonusShieldText->getSize().x;
 		} else {
 			allUI.bonusShieldImg->setPos(VOID_POS).setSize(VOID_SIZE);
 			allUI.bonusShieldText->setPos(VOID_POS).setSize(VOID_SIZE);

--- a/srcs/scenes/SceneGame.cpp
+++ b/srcs/scenes/SceneGame.cpp
@@ -301,7 +301,7 @@ bool	SceneGame::update() {
 	else if (state == GameState::WIN) {
 		AudioManager::stopAllSounds();
 		try {
-			AudioManager::playSound(WIN_SOUND);
+			AudioManager::playSound(WIN_SOUND, 1.0f, false, true);
 		} catch(Sound::SoundException const & e) {
 			logErr(e.what());
 		}
@@ -331,7 +331,7 @@ bool	SceneGame::update() {
 	else if (state == GameState::GAME_OVER) {
 		AudioManager::stopAllSounds();
 		try {
-			AudioManager::playSound(GAME_OVER_SOUND);
+			AudioManager::playSound(GAME_OVER_SOUND, 1.0f, false, true);
 		} catch(Sound::SoundException const & e) {
 			logErr(e.what());
 		}

--- a/srcs/scenes/SceneGameOver.cpp
+++ b/srcs/scenes/SceneGameOver.cpp
@@ -114,6 +114,7 @@ bool	SceneGameOver::update() {
  */
 void SceneGameOver::load() {
 	ASceneMenu::load();
+	AudioManager::playMusic(MUSIC_MENU, 0.1f, true);
 	if (SceneManager::getSceneName() != SceneNames::EXIT) {
 		_lastSceneName = SceneManager::getSceneName();
 	}

--- a/srcs/scenes/SceneLevelSelection.cpp
+++ b/srcs/scenes/SceneLevelSelection.cpp
@@ -196,7 +196,7 @@ bool	SceneLevelSelection::update() {
 void SceneLevelSelection::load() {
 	ASceneMenu::load();
 	_transition = 1;
-	setLevel(Save::getLastLevel());
+	setLevel(Save::getLastUnlockedLevel());
 }
 
 // -- Private methods ----------------------------------------------------------

--- a/srcs/scenes/SceneLevelSelection.cpp
+++ b/srcs/scenes/SceneLevelSelection.cpp
@@ -121,7 +121,11 @@ bool	SceneLevelSelection::update() {
 	// SceneGame reference
 	SceneGame & scGame = *reinterpret_cast<SceneGame *>(SceneManager::getScene(SceneNames::GAME));
 
-	allUI.text->setText(scGame.getLevelName(_currentLvl));
+	try {
+		allUI.text->setText(scGame.getLevelName(_currentLvl));
+	} catch (SceneGame::SceneGameException &e) {
+		_currentLvl = 0;
+	}
 	if (Save::isLevelDone(_currentLvl)) {
 		allUI.score->setText("score: " + std::to_string(Save::getLevelScore(_currentLvl)));
 	} else if (_currentLvl == 0 || Save::isLevelDone(_currentLvl - 1) || SceneCheatCode::isLevelUnlocked(_currentLvl)) {
@@ -192,6 +196,7 @@ bool	SceneLevelSelection::update() {
 void SceneLevelSelection::load() {
 	ASceneMenu::load();
 	_transition = 1;
+	setLevel(Save::getLastLevel());
 }
 
 // -- Private methods ----------------------------------------------------------

--- a/srcs/scenes/SceneLoadGame.cpp
+++ b/srcs/scenes/SceneLoadGame.cpp
@@ -144,7 +144,10 @@ void SceneLoadGame::load() {
 			.setTextAlign(TextAlign::LEFT).setTextFont("text").setMaster(previewGame);
 		tempPrevPos.y -= tmpSize.y * 0.8;
 		previewGameUI.date = &addText(tempPrevPos, tempPrevSize, "")
-			.setTextFont("text") .setTextAlign(TextAlign::LEFT).setMaster(previewGame);
+			.setTextFont("text").setTextAlign(TextAlign::LEFT).setMaster(previewGame);
+		tempPrevPos.y -= tmpSize.y * 0.8;
+		previewGameUI.gameDifficulty = &addText(tempPrevPos, tempPrevSize, "")
+			.setTextFont("text").setTextAlign(TextAlign::LEFT).setMaster(previewGame);
 		tempPrevPos.y -= tmpSize.y * 0.8;
 		previewGameUI.levelsDone = &addText(tempPrevPos, tempPrevSize, "")
 			.setTextFont("text").setTextAlign(TextAlign::LEFT).setMaster(previewGame);
@@ -208,6 +211,14 @@ bool	SceneLoadGame::update() {
 				std::stringstream ss;
 				ss << std::put_time(&localTime, "%d/%m/%Y at %H:%M:%S");
 				previewGameUI.date->setText(ss.str());
+				std::string gameDifficulty = "Difficulty: ";
+				if (gameSaved->game->u("difficulty") == 1)
+					gameDifficulty += "Hard Core";
+				else if (gameSaved->game->u("difficulty") == 2)
+					gameDifficulty += "Medium";
+				else
+					gameDifficulty += "Easy";
+				previewGameUI.gameDifficulty->setText(gameDifficulty);
 				std::string lvlDone = "Levels done: ";
 				lvlDone += std::to_string(gameSaved->game->lj("levels").list.size());
 				previewGameUI.levelsDone->setText(lvlDone);

--- a/srcs/scenes/SceneLoadGame.cpp
+++ b/srcs/scenes/SceneLoadGame.cpp
@@ -208,8 +208,10 @@ bool	SceneLoadGame::update() {
 					gameDifficulty += "Hard Core";
 				else if (gameSaved->game->u("difficulty") == 2)
 					gameDifficulty += "Medium";
-				else
+				else if (gameSaved->game->u("difficulty") == 3)
 					gameDifficulty += "Easy";
+				else
+					gameDifficulty += "Beginner";
 				previewGameUI.gameDifficulty->setText(gameDifficulty);
 				std::string lvlDone = "Levels done: ";
 				lvlDone += std::to_string(gameSaved->game->lj("levels").list.size());

--- a/srcs/scenes/SceneMainMenu.cpp
+++ b/srcs/scenes/SceneMainMenu.cpp
@@ -62,8 +62,8 @@ bool			SceneMainMenu::init() {
 			.addButtonLeftListener(&_states.exit);
 		allUI.border = &addRect(VOID_SIZE, VOID_SIZE);
 
-		AudioManager::loadMusic("sounds/puzzle.ogg");
-		AudioManager::playMusic("sounds/puzzle.ogg", 0.1f, true);
+		AudioManager::loadMusic("sounds/menu_loop.ogg");
+		AudioManager::playMusic("sounds/menu_loop.ogg", 0.1f, true);
 
 		_initBG();
 	}

--- a/srcs/scenes/SceneMainMenu.cpp
+++ b/srcs/scenes/SceneMainMenu.cpp
@@ -43,7 +43,7 @@ bool			SceneMainMenu::init() {
 		tmpSize.y = menuHeight;
 		addTitle(tmpPos, tmpSize, "Bomberman");
 
-		allUI.continueGame = &addButton(VOID_SIZE, VOID_SIZE, "continue")
+		allUI.continueGame = &addButton(VOID_SIZE, VOID_SIZE, "play")
 			.addButtonLeftListener(&_states.continueGame);
 		allUI.save = &addButton(VOID_SIZE, VOID_SIZE, "save")
 			.setKeyLeftClickScancode(SDL_SCANCODE_S)

--- a/srcs/scenes/SceneMainMenu.cpp
+++ b/srcs/scenes/SceneMainMenu.cpp
@@ -62,8 +62,8 @@ bool			SceneMainMenu::init() {
 			.addButtonLeftListener(&_states.exit);
 		allUI.border = &addRect(VOID_SIZE, VOID_SIZE);
 
-		AudioManager::loadMusic("sounds/menu_loop.ogg");
-		AudioManager::playMusic("sounds/menu_loop.ogg", 0.1f, true);
+		AudioManager::loadMusic(MUSIC_MENU);
+		AudioManager::playMusic(MUSIC_MENU, 0.1f, true);
 
 		_initBG();
 	}

--- a/srcs/scenes/SceneMainMenu.cpp
+++ b/srcs/scenes/SceneMainMenu.cpp
@@ -101,8 +101,7 @@ bool	SceneMainMenu::update() {
 	}
 	if (_states.newGame) {
 		_states.newGame = false;
-		Save::newGame();
-		SceneManager::loadScene(SceneNames::LEVEL_SELECTION);
+		SceneManager::loadScene(SceneNames::DIFFICULTY);
 	}
 	else if (_states.loadGame) {
 		_states.loadGame = false;

--- a/srcs/scenes/SceneManager.cpp
+++ b/srcs/scenes/SceneManager.cpp
@@ -9,6 +9,7 @@
 /* import all scenes */
 #include "SceneMainMenu.hpp"
 #include "SceneLevelSelection.hpp"
+#include "SceneDifficulty.hpp"
 #include "SceneGame.hpp"
 #include "ScenePause.hpp"
 #include "SceneGameOver.hpp"
@@ -99,6 +100,8 @@ bool SceneManager::_init() {
 	_sceneMap.insert(std::pair<std::string, AScene *>(SceneNames::MAIN_MENU, new SceneMainMenu(_gui, _dtTime)));
 	_sceneMap.insert(std::pair<std::string, AScene *>(SceneNames::LEVEL_SELECTION,
 		new SceneLevelSelection(_gui, _dtTime)));
+	_sceneMap.insert(std::pair<std::string, AScene *>(SceneNames::DIFFICULTY,
+		new SceneDifficulty(_gui, _dtTime)));
 	_sceneMap.insert(std::pair<std::string, AScene *>(SceneNames::GAME, new SceneGame(_gui, _dtTime)));
 	_sceneMap.insert(std::pair<std::string, AScene *>(SceneNames::PAUSE, new ScenePause(_gui, _dtTime)));
 	_sceneMap.insert(std::pair<std::string, AScene *>(SceneNames::GAME_OVER, new SceneGameOver(_gui, _dtTime)));

--- a/srcs/scenes/ScenePause.cpp
+++ b/srcs/scenes/ScenePause.cpp
@@ -103,6 +103,7 @@ bool	ScenePause::update() {
 	else if (_states.menu) {
 		_states.menu = false;
 		AudioManager::stopAllSounds();
+		AudioManager::playMusic(MUSIC_MENU, 0.1f, true);
 		SceneManager::loadScene(SceneNames::MAIN_MENU);
 	}
 	else if (_states.exit) {

--- a/srcs/scenes/SceneVictory.cpp
+++ b/srcs/scenes/SceneVictory.cpp
@@ -39,6 +39,7 @@ bool			SceneVictory::init() {
 	float menuHeight = winSz.y / 14;
 	float statisticHeight = menuHeight * 0.6;
 
+
 	try {
 		tmpPos.x = (winSz.x / 2) - (menuWidth / 2);
 		tmpPos.y = winSz.y - menuHeight * 2;
@@ -203,6 +204,7 @@ bool	SceneVictory::update() {
  */
 void SceneVictory::load() {
 	ASceneMenu::load();
+	AudioManager::playMusic(MUSIC_MENU, 0.1f, true);
 	if (SceneManager::getSceneName() != SceneNames::EXIT) {
 		_lastSceneName = SceneManager::getSceneName();
 	}


### PR DESCRIPTION
Level design : fix #154
> 24 niveaux,  dont 3 levels boss.
> il y a 7 musiques qui sont mises aléatoirement sur les levels. Et les levels boss ont leurs musiques propre. Certains niveaux ont des noms.

- alignement des bonus sur le côté gauche en vertical
- les bonus pris ont un halo pendant 3 secondes pour mieux identifier leur positions.
- ajout de 4 mode de difficulté dans le jeu : beginner (10 vies), facile (3 vies), moyen (2 vies), hard core (1 vie). fix #180
- les bonus clignotes 2 secondes avant de disparaître. fix #187
- la musique est coupée pendant les sons de win ou de game over. fix #186
- la selection de levels est chargée sur le dernier niveau débloqué (sauvegardé), pas avec le cheatcode unlock. fix #188 
