### PR TITLE
Bonus model rendering

### DIFF
--- a/includes/elements/Bonus.hpp
+++ b/includes/elements/Bonus.hpp
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <map>
+#include <unordered_map>
 #include <stdexcept>
 #include "AObject.hpp"
 #include "SceneGame.hpp"
@@ -35,12 +36,15 @@ private:
 	static std::map<BonusType::Enum, Block::Enum>	_textures;
 	int					_toDraw;
 	float				_indestructible;
+
 	// Methods
 	BonusType::Enum		_pickBonus();
 
 public:
 	static std::unordered_map<std::string, BonusType::Enum>	bonus;
-	static std::map<BonusType::Enum, std::string>			description;
+	static std::unordered_map<BonusType::Enum, std::string>	description;
+	static std::unordered_map<BonusType::Enum, std::string>	bonusTextures;
+
 	// Constructors
 	explicit Bonus(SceneGame &game);
 	~Bonus();
@@ -50,6 +54,7 @@ public:
 	Bonus &operator=(Bonus const &rhs);
 
 	// Methods
+	bool				init();
 	bool				update();
 	bool				postUpdate();
 	bool				draw(Gui &gui);

--- a/includes/utils/opengl/Material.hpp
+++ b/includes/utils/opengl/Material.hpp
@@ -9,15 +9,17 @@
  */
 class Material {
 	public:
-		Material(glm::vec3 const diffuse = glm::vec3(.36f, .34f, .32f), \
-		glm::vec3 const specular = glm::vec3(.3f, .3f, .3f), \
-		glm::vec3 const ambient = glm::vec3(0.2f, 0.2f, 0.2f), \
-		float const shininess = 16.0f);
+		Material(std::string const name = "",
+			glm::vec3 const diffuse = glm::vec3(.36f, .34f, .32f), \
+			glm::vec3 const specular = glm::vec3(.3f, .3f, .3f), \
+			glm::vec3 const ambient = glm::vec3(0.2f, 0.2f, 0.2f), \
+			float const shininess = 16.0f);
 		Material(Material const &src);
 		virtual ~Material();
 
 		Material &operator=(Material const &rhs);
 
+		std::string	name;
 		glm::vec3	diffuse;
 		glm::vec3	specular;
 		glm::vec3	ambient;

--- a/includes/utils/opengl/Mesh.hpp
+++ b/includes/utils/opengl/Mesh.hpp
@@ -60,7 +60,7 @@ class	Mesh {
 		Mesh(Mesh const &src);
 		Mesh &operator=(Mesh const &rhs);
 
-		void	setTexture(Texture const texture);
+		void	setTexture(TextureType::Enum type, Texture const texture);
 		void	draw(glm::mat4 const &model) const;
 		void	addBoneData(uint32_t boneID, float weight, uint32_t VerticeID);
 		void	sendMesh();

--- a/includes/utils/opengl/Mesh.hpp
+++ b/includes/utils/opengl/Mesh.hpp
@@ -4,7 +4,7 @@
 #define NB_BONES_PER_VERTEX 4
 
 #include <vector>
-#include <map>
+#include <unordered_map>
 #include <array>
 
 #include "includesOpengl.hpp"
@@ -53,13 +53,14 @@ struct	Texture {
  */
 class	Mesh {
 	public:
-		Mesh(OpenGLModel &openGLModel, Shader &sh, std::string const &name, std::vector<Vertex> vertices,
-			std::vector<uint32_t> vertIndices, std::vector<Texture> textures,
+		Mesh(OpenGLModel &openGLModel, Shader &sh, std::string const &name,
+			std::vector<Vertex> vertices, std::vector<uint32_t> vertIndices,
 			Material material, BoundingBox boundingBox);
 		virtual ~Mesh();
 		Mesh(Mesh const &src);
 		Mesh &operator=(Mesh const &rhs);
 
+		void	setTexture(Texture const texture);
 		void	draw(glm::mat4 const &model) const;
 		void	addBoneData(uint32_t boneID, float weight, uint32_t VerticeID);
 		void	sendMesh();
@@ -73,7 +74,7 @@ class	Mesh {
 		std::string				_name;
 		std::vector<Vertex>		_vertices;
 		std::vector<uint32_t>	_vertIndices;  // contain _vertices id
-		std::vector<Texture>	_textures;
+		std::unordered_map<TextureType::Enum, Texture>	_textures;
 		Material				_material;
 		BoundingBox				_boundingBox;
         uint32_t				_vao;

--- a/includes/utils/opengl/Model.hpp
+++ b/includes/utils/opengl/Model.hpp
@@ -30,6 +30,8 @@ class Model {
 			AEntity *animEndCbClass = nullptr);
 		void	setAnimProgress(float progress);
 		void	setAnimCurrentTime(float animTime);
+		void	setMeshTexture(TextureType::Enum type, std::string const meshName,
+			std::string const path, bool inSpaceSRGB = true);
 
 		float	getAnimCurrentTime() const;
 		float	getAnimProgress() const;

--- a/includes/utils/opengl/Model.hpp
+++ b/includes/utils/opengl/Model.hpp
@@ -49,6 +49,13 @@ class Model {
 		void	_updateAnimationTime();
 		void	_updateTicksPerSecond();
 
+		struct	MeshTexture {
+			TextureType::Enum	type;
+			std::string			meshName;
+			std::string			path;
+			bool				inSpaceSRGB;
+		};
+
 		OpenGLModel &_openGLModel;
 		float const	&_dtTime;
 		uint32_t	_animationId;
@@ -58,6 +65,7 @@ class Model {
 		float		_animationTimeTick;
 		AnimEndCb	_animEndCbFunc;  // cb function called on animation end
 		AEntity		*_animEndCbClass;  // cb class called on animation end
+		std::vector<Model::MeshTexture>	_meshTextures;  // store manually modified mesh textures
 };
 
 #endif  // MODEL_HPP_

--- a/includes/utils/opengl/OpenGLModel.hpp
+++ b/includes/utils/opengl/OpenGLModel.hpp
@@ -114,7 +114,7 @@ class OpenGLModel {
 			float animationTimeTick, aiNodeAnim const *nodeAnim);
 
 		// -- utils ------------------------------------------------------------
-		void	loadTexture(TextureType::Enum type, std::string const path,
+		void	_loadTexture(TextureType::Enum type, std::string const path,
 			bool inSpaceSRGB);
 
 		// -- members ----------------------------------------------------------

--- a/includes/utils/opengl/OpenGLModel.hpp
+++ b/includes/utils/opengl/OpenGLModel.hpp
@@ -58,7 +58,11 @@ class OpenGLModel {
 		void		draw(float animationTimeTick = 0.0f);
 		bool		setAnimation(uint32_t id);
 		void		setModel(glm::mat4 const model);
+		void		setMeshTexture(TextureType::Enum type, std::string const meshName,
+			std::string const path, bool inSpaceSRGB = true);
+		void		printMeshesNames();
 
+		// getters
 		bool		getAnimationId(std::string const name, uint32_t &outId) const;
 		aiAnimation	*getAiAnimation(uint32_t id) const;
 		bool		isAnimated() const;
@@ -109,20 +113,25 @@ class OpenGLModel {
 		std::pair<uint32_t, uint32_t>	_findAnimIndex(AnimKeyType::Enum animType,
 			float animationTimeTick, aiNodeAnim const *nodeAnim);
 
+		// -- utils ------------------------------------------------------------
+		void	loadTexture(TextureType::Enum type, std::string const path,
+			bool inSpaceSRGB);
+
 		// -- members ----------------------------------------------------------
 		static std::unique_ptr<Shader>	_sh;
 
 		Camera const		&_cam;
 		std::string const	_path;  // model file path
-		std::vector<Mesh *>	_meshes;  // all model meshes
+		std::unordered_map<std::string, Mesh *>	_meshes;  // all model meshes
 
 		// assimp utility
 		aiScene const		*_scene;
 		Assimp::Importer	_importer;
 
 		// textures
-		std::vector<Texture>	_texturesLoaded;  // keep track of loaded textures
-		std::string				_pathDir;
+		// to keep track of loaded textures
+		std::unordered_map<std::string, Texture>	_texturesLoaded;
+		std::string	_pathDir;
 
 		// model position
 		glm::mat4	_model;  // position in real world

--- a/srcs/elements/Bonus.cpp
+++ b/srcs/elements/Bonus.cpp
@@ -33,7 +33,7 @@ std::unordered_map<std::string, BonusType::Enum> Bonus::bonus = {
 	{ "points", BonusType::POINTS },
 };
 
-std::map<BonusType::Enum, std::string> Bonus::description = {
+std::unordered_map<BonusType::Enum, std::string> Bonus::description = {
 	{ BonusType::LIFE, "Bonus Life: You earn an extra life." },
 	{ BonusType::BOMBS, "Bonus Bombs: You can put one more bomb simultaneously." },
 	{ BonusType::FLAMES, "Bonus Flames: The bombs explode at a greater range." },
@@ -45,6 +45,20 @@ std::map<BonusType::Enum, std::string> Bonus::description = {
 	{ BonusType::SHIELD, "Bonus Shield: You can't get damage for a while." },
 	{ BonusType::TIME, "Bonus Time: Extra time to finish the level." },
 	{ BonusType::POINTS, "Bonus Points: Your total score increase." },
+};
+
+std::unordered_map<BonusType::Enum, std::string> Bonus::bonusTextures = {
+	{ BonusType::LIFE, "bomberman-assets/3dModels/bonus/textures/life.png" },
+	{ BonusType::BOMBS, "bomberman-assets/3dModels/bonus/textures/bomb.png" },
+	{ BonusType::FLAMES, "bomberman-assets/3dModels/bonus/textures/flamme.png" },
+	{ BonusType::SPEED, "bomberman-assets/3dModels/bonus/textures/speed.png" },
+	{ BonusType::WALLPASS, "bomberman-assets/3dModels/bonus/textures/wallpass.png" },
+	{ BonusType::DETONATOR, "bomberman-assets/3dModels/bonus/textures/detonator.png" },
+	{ BonusType::BOMBPASS, "bomberman-assets/3dModels/bonus/textures/bombpass.png" },
+	{ BonusType::FLAMPASS, "bomberman-assets/3dModels/bonus/textures/flampass.png" },
+	{ BonusType::SHIELD, "bomberman-assets/3dModels/bonus/textures/shield.png" },
+	{ BonusType::TIME, "bomberman-assets/3dModels/bonus/textures/time.png" },
+	{ BonusType::POINTS, "bomberman-assets/3dModels/bonus/textures/score.png" },
 };
 
 // -- Constructors -------------------------------------------------------------
@@ -151,12 +165,26 @@ bool	Bonus::postUpdate() {
  * @return false if failure
  */
 bool	Bonus::draw(Gui &gui) {
+	(void)gui;
+
+	// flash before dying
 	if (_timeToDie <= 2) {
 		_toDraw = ((_toDraw + 1) % 10);
 		if (_toDraw > 5)
 			return true;
 	}
-	gui.drawCube(_textures[_typeBonus], getPos());
+
+	// gui.drawCube(_textures[_typeBonus], getPos());
+
+	// draw model
+	try {
+		_model->draw();
+	}
+	catch(OpenGLModel::ModelException const & e) {
+		logErr(e.what());
+		return false;
+	}
+
 	return true;
 }
 
@@ -232,6 +260,40 @@ BonusType::Enum		Bonus::_pickBonus() {
 			}
 		}
 	}
+}
+
+/**
+ * @brief Init Bonus
+ *
+ * @return true on success
+ * @return false on failure
+ */
+bool	Bonus::init() {
+	AObject::init();
+
+	try {
+		// if exist, delete last model
+		if (_model)
+			delete _model;
+
+		_model = new Model(ModelsManager::getModel("bonus"), game.getDtTime(),
+			ETransform((position + glm::vec3(.5, 0, .5))));
+		_model->play = true;
+		_model->loopAnimation = true;
+		_model->setAnimation("Armature|idle");
+		_model->setMeshTexture(TextureType::DIFFUSE, "Bonus_Mesh::Bonus",
+			bonusTextures[_typeBonus]);
+	}
+	catch(ModelsManager::ModelsManagerException const &e) {
+		logErr(e.what());
+		return false;
+	}
+	catch(OpenGLModel::ModelException const &e) {
+		logErr(e.what());
+		return false;
+	}
+
+	return true;
 }
 
 // -- Exceptions errors --------------------------------------------------------

--- a/srcs/gui/ModelsManager.cpp
+++ b/srcs/gui/ModelsManager.cpp
@@ -81,6 +81,9 @@ bool	ModelsManager::_init(Camera const &cam) {
 
 			_models["terrain"] = new OpenGLModel(cam, "bomberman-assets/3dModels/"
 				"terrain/terrain.fbx");
+
+			_models["bonus"] = new OpenGLModel(cam, "bomberman-assets/3dModels/"
+				"bonus/bonus.fbx");
 		}
 		catch(OpenGLModel::ModelException const & e) {
 			logErr(e.what());

--- a/srcs/utils/opengl/Material.cpp
+++ b/srcs/utils/opengl/Material.cpp
@@ -1,8 +1,9 @@
 #include "Material.hpp"
 
-Material::Material(glm::vec3 const diffuse, glm::vec3 const specular, \
-glm::vec3 const ambient, float const shininess)
-: diffuse(diffuse),
+Material::Material(std::string const name, glm::vec3 const diffuse,
+	glm::vec3 const specular, glm::vec3 const ambient, float const shininess)
+: name(name),
+  diffuse(diffuse),
   specular(specular),
   ambient(ambient),
   shininess(shininess) {
@@ -17,6 +18,7 @@ Material::~Material() {
 
 Material &Material::operator=(Material const &rhs) {
 	if (this != &rhs) {
+		name = rhs.name;
 		diffuse = rhs.diffuse;
 		specular = rhs.specular;
 		ambient = rhs.ambient;
@@ -27,7 +29,7 @@ Material &Material::operator=(Material const &rhs) {
 
 
 std::ostream & operator << (std::ostream &out, Material const &m) {
-	out << "{" << std::endl;
+	out << m.name << ": {" << std::endl;
 	out << "  diffuse: " << glm::to_string(m.diffuse) << "," << std::endl;
 	out << "  specular: " << glm::to_string(m.specular) << "," << std::endl;
 	out << "  ambient: " << glm::to_string(m.ambient) << "," << std::endl;

--- a/srcs/utils/opengl/Mesh.cpp
+++ b/srcs/utils/opengl/Mesh.cpp
@@ -6,13 +6,13 @@
 // -- Constructors -------------------------------------------------------------
 Mesh::Mesh(OpenGLModel &openGLModel, Shader &sh, std::string const &name,
 	std::vector<Vertex> vertices, std::vector<u_int32_t> vertIndices,
-	std::vector<Texture> textures, Material material, BoundingBox boundingBox)
+	Material material, BoundingBox boundingBox)
 : _openGLModel(openGLModel),
   _sh(sh),
   _name(name),
   _vertices(vertices),
   _vertIndices(vertIndices),
-  _textures(textures),
+  _textures({}),
   _material(material),
   _boundingBox(boundingBox),
   _vao(0),
@@ -21,7 +21,9 @@ Mesh::Mesh(OpenGLModel &openGLModel, Shader &sh, std::string const &name,
 
 Mesh::Mesh(Mesh const &src)
 : _openGLModel(src._openGLModel),
-  _sh(src._sh) {
+  _sh(src._sh),
+  _textures({})
+{
 	*this = src;
 }
 
@@ -39,6 +41,8 @@ Mesh::~Mesh() {
 
 Mesh &Mesh::operator=(Mesh const &rhs) {
 	if (this != &rhs) {
+		logWarn("Mesh is copied");
+
 		_vertices = rhs._vertices;
 		_vertIndices = rhs._vertIndices;
 		_textures = rhs._textures;
@@ -49,6 +53,17 @@ Mesh &Mesh::operator=(Mesh const &rhs) {
 	}
 	return *this;
 }
+
+// -- setTexture ---------------------------------------------------------------------
+/**
+ * @brief Set the Texture object, the type is retrieve from texture.type
+ *
+ * @param texture the new texture value
+ */
+void	Mesh::setTexture(Texture const texture) {
+	_textures.insert({texture.type, texture});
+}
+
 
 // -- draw ---------------------------------------------------------------------
 /**
@@ -86,34 +101,42 @@ void	Mesh::_setUniformsTextures() const {
 	bool	hasNormalTex = false;
 
 	_sh.use();
-	// set textures uniforms
+	/* set textures uniforms */
 	uint32_t	i = 0;
-	for (Texture const &tex : _textures) {
-		glActiveTexture(GL_TEXTURE0 + i);
 
-		// diffuse texture
-		if (tex.type == TextureType::DIFFUSE && !hasDiffuseTex) {
-			hasDiffuseTex = true;
-			_sh.setBool("material.diffuse.isTexture", true);
-			_sh.setInt("material.diffuse.texture", i);
-			glBindTexture(GL_TEXTURE_2D, tex.id);
-		}
-		// specular texture
-		else if (tex.type == TextureType::SPECULAR && !hasSpecularTex) {
-			hasSpecularTex = true;
-			_sh.setBool("material.specular.isTexture", true);
-			_sh.setInt("material.specular.texture", i);
-			glBindTexture(GL_TEXTURE_2D, tex.id);
-		}
-		// normal texture
-		else if (tex.type == TextureType::NORMAL && !hasNormalTex) {
-			hasNormalTex = true;
-			_sh.setBool("material.normalMap.isTexture", true);
-			_sh.setInt("material.normalMap.texture", i);
-			glBindTexture(GL_TEXTURE_2D, tex.id);
-		}
+	// diffuse texture
+	auto	it = _textures.find(TextureType::DIFFUSE);
+	if (it != _textures.end()) {
+		glActiveTexture(GL_TEXTURE0 + i);
+		hasDiffuseTex = true;
+		_sh.setBool("material.diffuse.isTexture", true);
+		_sh.setInt("material.diffuse.texture", i);
+		glBindTexture(GL_TEXTURE_2D, it->second.id);
 		++i;
 	}
+
+	// specular texture
+	it = _textures.find(TextureType::SPECULAR);
+	if (it != _textures.end()) {
+		glActiveTexture(GL_TEXTURE0 + i);
+		hasSpecularTex = true;
+		_sh.setBool("material.specular.isTexture", true);
+		_sh.setInt("material.specular.texture", i);
+		glBindTexture(GL_TEXTURE_2D, it->second.id);
+		++i;
+	}
+
+	// normal texture
+	it = _textures.find(TextureType::NORMAL);
+	if (it != _textures.end()) {
+		glActiveTexture(GL_TEXTURE0 + i);
+		hasNormalTex = true;
+		_sh.setBool("material.normalMap.isTexture", true);
+		_sh.setInt("material.normalMap.texture", i);
+		glBindTexture(GL_TEXTURE_2D, it->second.id);
+		++i;
+	}
+
 	glActiveTexture(GL_TEXTURE0);
 
 	// set diffuse color if no texture has been setted

--- a/srcs/utils/opengl/Mesh.cpp
+++ b/srcs/utils/opengl/Mesh.cpp
@@ -68,7 +68,7 @@ Mesh &Mesh::operator=(Mesh const &rhs) {
  * @param texture Texture object
  */
 void	Mesh::setTexture(TextureType::Enum type, Texture const texture) {
-	_textures.insert({type, texture});
+	_textures[type] = texture;
 }
 
 

--- a/srcs/utils/opengl/Mesh.cpp
+++ b/srcs/utils/opengl/Mesh.cpp
@@ -60,8 +60,15 @@ Mesh &Mesh::operator=(Mesh const &rhs) {
  *
  * @param texture the new texture value
  */
-void	Mesh::setTexture(Texture const texture) {
-	_textures.insert({texture.type, texture});
+
+/**
+ * @brief set Mesh texture
+ *
+ * @param type the texture type DIFFUSE/SPECULAR/NORMAL/...
+ * @param texture Texture object
+ */
+void	Mesh::setTexture(TextureType::Enum type, Texture const texture) {
+	_textures.insert({type, texture});
 }
 
 

--- a/srcs/utils/opengl/Mesh.cpp
+++ b/srcs/utils/opengl/Mesh.cpp
@@ -56,12 +56,6 @@ Mesh &Mesh::operator=(Mesh const &rhs) {
 
 // -- setTexture ---------------------------------------------------------------------
 /**
- * @brief Set the Texture object, the type is retrieve from texture.type
- *
- * @param texture the new texture value
- */
-
-/**
  * @brief set Mesh texture
  *
  * @param type the texture type DIFFUSE/SPECULAR/NORMAL/...

--- a/srcs/utils/opengl/Model.cpp
+++ b/srcs/utils/opengl/Model.cpp
@@ -68,6 +68,11 @@ void	Model::draw() {
 		}
 	}
 
+	// set manually modified mesh textures if specified
+	for (MeshTexture &mT : _meshTextures) {
+		_openGLModel.setMeshTexture(mT.type, mT.meshName, mT.path, mT.inSpaceSRGB);
+	}
+
 	// update openGLModel model matrix
 	_openGLModel.setModel(transform.getModel());
 
@@ -177,6 +182,8 @@ void	Model::setAnimCurrentTime(float animTime) {
 
 /**
  * @brief manually set the texture of a specified mesh
+ * Warning: others Model that use the same OpenglModel will also have their mesh
+ * texture modified if they not replace it
  *
  * @param type the texture type DIFFUSE/SPECULAR/NORMAL/...
  * @param meshName the name of the desired mesh, find it with printMeshesNames
@@ -184,8 +191,15 @@ void	Model::setAnimCurrentTime(float animTime) {
  * @param inSpaceSRGB is the texture in srgb space ?
  */
 void	Model::setMeshTexture(TextureType::Enum type, std::string const meshName,
-	std::string const path, bool inSpaceSRGB) {
-	_openGLModel.setMeshTexture(type, meshName, path, inSpaceSRGB);
+	std::string const path, bool inSpaceSRGB)
+{
+	MeshTexture	meshTexture;
+	meshTexture.type = type;
+	meshTexture.meshName = meshName;
+	meshTexture.path = path;
+	meshTexture.inSpaceSRGB = inSpaceSRGB;
+
+	_meshTextures.push_back(meshTexture);
 }
 
 // -- getters ------------------------------------------------------------------

--- a/srcs/utils/opengl/Model.cpp
+++ b/srcs/utils/opengl/Model.cpp
@@ -175,6 +175,19 @@ void	Model::setAnimCurrentTime(float animTime) {
 	}
 }
 
+/**
+ * @brief manually set the texture of a specified mesh
+ *
+ * @param type the texture type DIFFUSE/SPECULAR/NORMAL/...
+ * @param meshName the name of the desired mesh, find it with printMeshesNames
+ * @param path the texture path
+ * @param inSpaceSRGB is the texture in srgb space ?
+ */
+void	Model::setMeshTexture(TextureType::Enum type, std::string const meshName,
+	std::string const path, bool inSpaceSRGB) {
+	_openGLModel.setMeshTexture(type, meshName, path, inSpaceSRGB);
+}
+
 // -- getters ------------------------------------------------------------------
 /**
  * @brief get the curent animation time in ms

--- a/srcs/utils/opengl/OpenGLModel.cpp
+++ b/srcs/utils/opengl/OpenGLModel.cpp
@@ -292,7 +292,7 @@ void	OpenGLModel::_processMesh(aiMesh *aiMesh, aiScene const *scene) {
 	// load material
 	Material	mat = _loadMaterial(material);
 
-	/* create uniq Mesh name */
+	/* create uniques Meshes name */
 	std::string	baseName = std::string(aiMesh->mName.C_Str()) + "::" + mat.name;
 	std::string meshName = baseName;
 	// if the name already exist prepend a number
@@ -605,7 +605,7 @@ bool	OpenGLModel::getAnimationId(std::string const name, uint32_t &outId) const 
 void	OpenGLModel::setMeshTexture(TextureType::Enum type, std::string const meshName,
 	std::string const path, bool inSpaceSRGB)
 {
-	loadTexture(type, path, inSpaceSRGB);
+	_loadTexture(type, path, inSpaceSRGB);
 
 	// load only if the texture was not previously loaded
 	auto	it = _texturesLoaded.find(path);
@@ -880,7 +880,7 @@ std::pair<uint32_t, uint32_t>	OpenGLModel::_findAnimIndex(AnimKeyType::Enum anim
 	return std::make_pair(lastI, lastI);
 }
 
-// -- loadTexture --------------------------------------------------------------
+// -- _loadTexture --------------------------------------------------------------
 /**
  * @brief load new texture manually
  *
@@ -888,7 +888,7 @@ std::pair<uint32_t, uint32_t>	OpenGLModel::_findAnimIndex(AnimKeyType::Enum anim
  * @param path
  * @param inSpaceSRGB
  */
-void	OpenGLModel::loadTexture(TextureType::Enum type, std::string const path,
+void	OpenGLModel::_loadTexture(TextureType::Enum type, std::string const path,
 	bool inSpaceSRGB)
 {
 	// load only if the texture was not previously loaded

--- a/srcs/utils/opengl/OpenGLModel.cpp
+++ b/srcs/utils/opengl/OpenGLModel.cpp
@@ -351,6 +351,12 @@ Material	OpenGLModel::_loadMaterial(aiMaterial *aiMat) {
 	Material	mat;
 	aiColor3D	color(0.f, 0.f, 0.f);
 	float		shininess;
+	aiString	matName;
+
+	// name
+	if (aiMat->Get(AI_MATKEY_NAME, matName) == AI_SUCCESS) {
+		mat.name = matName.C_Str();
+	}
 
 	// diffuse
 	if (aiMat->Get(AI_MATKEY_COLOR_DIFFUSE, color) == AI_SUCCESS) {

--- a/srcs/utils/opengl/OpenGLModel.cpp
+++ b/srcs/utils/opengl/OpenGLModel.cpp
@@ -613,7 +613,7 @@ void	OpenGLModel::setMeshTexture(TextureType::Enum type, std::string const meshN
 		// it->second
 
 		auto	meshIt = _meshes.find(meshName);
-		if (it != _texturesLoaded.end()) {
+		if (meshIt != _meshes.end()) {
 			meshIt->second->setTexture(type, it->second);
 			return;
 		}

--- a/srcs/utils/opengl/OpenGLModel.cpp
+++ b/srcs/utils/opengl/OpenGLModel.cpp
@@ -291,7 +291,12 @@ void	OpenGLModel::_processMesh(aiMesh *aiMesh, aiScene const *scene) {
 
 	// create the mesh
 	Mesh	*mesh = new Mesh(*this, *_sh, aiMesh->mName.C_Str(), vertices, vertIndices,
-		textures, mat, boundingBox);
+		mat, boundingBox);
+
+	// set mesh textures
+	for (Texture const &tex : textures) {
+		mesh->setTexture(tex);
+	}
 
 	// process mesh bones
 	_processBones(aiMesh, *mesh);


### PR DESCRIPTION
Ça y est les bonus ont leurs modeles 😎.
J'ai pas mal galéré parce-que j'ai du faire un systeme pour changer la texture d'un Mesh depuis le code (pour pas avoir a dupliquer salement x fois le même modele avec juste une texture differente).
Du coup maintenant il y a une fonction `Model::setMeshTexture` pour ça.

```c++
/**
 * @brief manually set the texture of a specified mesh
 * Warning: others Model that use the same OpenglModel will also have their mesh
 * texture modified if they not replace it
 *
 * @param type the texture type DIFFUSE/SPECULAR/NORMAL/...
 * @param meshName the name of the desired mesh, find it with printMeshesNames
 * @param path the texture path
 * @param inSpaceSRGB is the texture in srgb space ?
 */
void	Model::setMeshTexture(TextureType::Enum type, std::string const meshName,
	std::string const path, bool inSpaceSRGB = true);
```
close #75