### PR TITLE
getStats functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ SRC =	main.cpp \
 		utils/Logging.cpp \
 		utils/SettingsJson.cpp \
 		utils/FileUtils.cpp \
+		utils/Stats.cpp \
 \
 		utils/opengl/Inputs.cpp \
 		utils/opengl/Texture.cpp \
@@ -246,6 +247,7 @@ HEAD =	bomberman.hpp \
 		utils/SettingsJson.hpp \
 		utils/FileUtils.hpp \
 		utils/useGlm.hpp \
+		utils/Stats.hpp \
 \
 		utils/opengl/Inputs.hpp \
 		utils/opengl/Texture.hpp \

--- a/includes/utils/Logging.hpp
+++ b/includes/utils/Logging.hpp
@@ -6,6 +6,8 @@
 #include <iomanip>
 #include <sstream>
 
+#include "Stats.hpp"
+
 #define COLOR_EOC		"\x1B[0m"
 #define COLOR_RED		"\x1B[31m"
 #define COLOR_GREEN		"\x1B[32m"

--- a/includes/utils/Stats.hpp
+++ b/includes/utils/Stats.hpp
@@ -1,0 +1,67 @@
+#ifndef STATS_HPP_
+#define STATS_HPP_
+#include <unordered_map>
+#include <iostream>
+#include <string>
+#include <chrono>
+
+/**
+ * @brief sStat element (to store the stats of a function call)
+ */
+struct sStat {
+	int	nbCalls;  ///< Number of function call
+	std::chrono::duration<double>	totalExecTime;  ///< Total execution time
+	std::chrono::duration<double>	avgExecTime;  ///< Average execution time
+	std::chrono::duration<double>	minExecTime;  ///< Min execution time
+	std::chrono::duration<double>	maxExecTime;  ///< Max execution time
+};
+
+/**
+ * @brief Stats object to manage functions calls stats
+ */
+class Stats {
+	public:
+		Stats();
+		~Stats();
+		static std::chrono::high_resolution_clock::time_point	startStats(std::string name);
+		static void	endStats(std::string name, std::chrono::high_resolution_clock::time_point startExecTime);
+		static void	printStats();
+
+		// Members
+		static std::unordered_map<std::string, struct sStat>	stats;  ///< Stats are stored here
+};
+
+// -- getStats for clasic functions --------------------------------------------
+
+template<typename RetT, typename ...Args>
+RetT getStats(std::string name, RetT (&func)(Args...), Args... args) {
+	std::chrono::high_resolution_clock::time_point startExecTime = Stats::startStats(name);
+	RetT res = func(args...);
+    Stats::endStats(name, startExecTime);
+	return res;
+}
+template<typename ...Args>
+void getStatsVoid(std::string name, void (&func)(Args...), Args... args) {
+	std::chrono::high_resolution_clock::time_point startExecTime = Stats::startStats(name);
+	func(args...);
+    Stats::endStats(name, startExecTime);
+}
+
+
+// -- getStats for member function ---------------------------------------------
+
+template<typename RetT, typename ClassT, typename ...Args>
+RetT getStatsM(std::string name, ClassT &obj, RetT (ClassT::*func)(Args...), Args... args) {
+	std::chrono::high_resolution_clock::time_point startExecTime = Stats::startStats(name);
+	RetT res = (obj.*func)(args...);
+    Stats::endStats(name, startExecTime);
+	return res;
+}
+template<typename ClassT, typename ...Args>
+void getStatsMVoid(std::string name, ClassT &obj, void (ClassT::*func)(Args...), Args... args) {
+	std::chrono::high_resolution_clock::time_point startExecTime = Stats::startStats(name);
+	(obj.*func)(args...);
+    Stats::endStats(name, startExecTime);
+}
+
+#endif  // STATS_HPP_

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -58,6 +58,10 @@ int bomberman(int ac, char const ** av) {
 		return EXIT_FAILURE;
 	}
 
+	#if DEBUG
+		Stats::printStats();
+	#endif
+
 	/* save before quit */
 	saveSettings(homeDir+SETTINGS_FILE);
 	return ret;

--- a/srcs/scenes/SceneManager.cpp
+++ b/srcs/scenes/SceneManager.cpp
@@ -290,13 +290,7 @@ bool SceneManager::_update() {
 	/* scene */
 	if (!_isInCheatCode && !cheatCodeClosed) {
 		// update the scene
-		if (_scene == SceneNames::GAME) {
-			if (getStatsM<bool, AScene>("SceneGame update", *_sceneMap[_scene], &AScene::update) == false) {
-				logErr("Unexpected error when updating scene");
-				return false;
-			}
-		}
-		else if (_sceneMap[_scene]->update() == false) {
+		if (_sceneMap[_scene]->update() == false) {
 			logErr("Unexpected error when updating scene");
 			return false;
 		}
@@ -325,13 +319,7 @@ bool SceneManager::_draw() {
 	}
 
 	// draw the scene
-	if (_scene == SceneNames::GAME) {
-		if (getStatsM<bool, AScene>("SceneGame draw", *_sceneMap[_scene], &AScene::draw) == false) {
-			logErr("Unexpected error when drawing scene");
-			return false;
-		}
-	}
-	else if (_sceneMap[_scene]->draw() == false) {
+	if (_sceneMap[_scene]->draw() == false) {
 		logErr("Unexpected error when drawing scene");
 		return false;
 	}

--- a/srcs/scenes/SceneManager.cpp
+++ b/srcs/scenes/SceneManager.cpp
@@ -290,8 +290,14 @@ bool SceneManager::_update() {
 	/* scene */
 	if (!_isInCheatCode && !cheatCodeClosed) {
 		// update the scene
-		if (_sceneMap[_scene]->update() == false) {
-			logErr("Unexpected error when drawing scene");
+		if (_scene == SceneNames::GAME) {
+			if (getStatsM<bool, AScene>("SceneGame update", *_sceneMap[_scene], &AScene::update) == false) {
+				logErr("Unexpected error when updating scene");
+				return false;
+			}
+		}
+		else if (_sceneMap[_scene]->update() == false) {
+			logErr("Unexpected error when updating scene");
 			return false;
 		}
 	}
@@ -319,7 +325,14 @@ bool SceneManager::_draw() {
 	}
 
 	// draw the scene
-	if (_sceneMap[_scene]->draw() == false) {
+	if (_scene == SceneNames::GAME) {
+		if (getStatsM<bool, AScene>("SceneGame draw", *_sceneMap[_scene], &AScene::draw) == false) {
+			logErr("Unexpected error when drawing scene");
+			return false;
+		}
+	}
+	else if (_sceneMap[_scene]->draw() == false) {
+		logErr("Unexpected error when drawing scene");
 		return false;
 	}
 

--- a/srcs/utils/Stats.cpp
+++ b/srcs/utils/Stats.cpp
@@ -1,0 +1,83 @@
+#include "Stats.hpp"
+#include <algorithm>
+#include <iomanip>
+
+#include "Logging.hpp"
+
+std::unordered_map<std::string, struct sStat> Stats::stats = {};
+
+/**
+ * @brief Construct a new Stats object
+ */
+Stats::Stats() {
+}
+
+/**
+ * @brief Destroy a Stats object
+ */
+Stats::~Stats() {
+}
+
+/**
+ * @brief Print functions stats, print only the one that has been called
+ * with getStats
+ */
+void    Stats::printStats() {
+    if (stats.size() > 0) {
+        logDebug("functions calls stats:");
+    }
+
+    for (auto const &stat : stats) {
+        logDebug(stat.first << "{");
+        logDebug("  function called: " << stat.second.nbCalls << " times");
+        logDebug("  total exec time: " << std::fixed << std::setprecision(8) <<
+            stat.second.totalExecTime.count() << "s");
+        logDebug("  average: " << std::fixed << std::setprecision(8) <<
+            stat.second.avgExecTime.count() << "s");
+        if (stat.second.minExecTime != std::chrono::duration<double>::max()) {
+            logDebug("  min: " << std::fixed << std::setprecision(8) <<
+                stat.second.minExecTime.count() << "s");
+        }
+        if (stat.second.maxExecTime != std::chrono::duration<double>::min()) {
+            logDebug("  min: " << std::fixed << std::setprecision(8) <<
+                stat.second.maxExecTime.count() << "s");
+        }
+        logDebug("}");
+    }
+}
+
+/**
+ * @brief Called by getStats to init the stats, no need to manually call
+ *
+ * @param name the function name
+ * @return std::chrono::high_resolution_clock::time_point, the start execution time
+ */
+std::chrono::high_resolution_clock::time_point  Stats::startStats(std::string name) {
+    if (Stats::stats.find(name) == Stats::stats.end()) {
+        struct sStat stats;
+        stats.nbCalls = 0;
+        stats.totalExecTime = std::chrono::duration<double>(0);
+        stats.avgExecTime = std::chrono::duration<double>(0);
+        stats.minExecTime = std::chrono::duration<double>::max();
+        stats.maxExecTime = std::chrono::duration<double>::min();
+        Stats::stats[name] = stats;
+    }
+    ++(Stats::stats[name].nbCalls);
+    return std::chrono::high_resolution_clock::now();
+}
+
+/**
+ * @brief Called by getStats to stop the stats count, no need to manually call
+ */
+void	Stats::endStats(std::string name, std::chrono::high_resolution_clock::time_point \
+startExecTime) {
+    if (Stats::stats.find(name) == Stats::stats.end()
+    || startExecTime == std::chrono::high_resolution_clock::time_point::min())
+        return;
+    std::chrono::duration<double> execTime = std::chrono::duration_cast<std::chrono::duration<double> >(
+        std::chrono::high_resolution_clock::now() - startExecTime);
+    Stats::stats[name].totalExecTime += execTime;
+    Stats::stats[name].avgExecTime = Stats::stats[name].totalExecTime / Stats::stats[name].nbCalls;
+    Stats::stats[name].minExecTime = std::min(Stats::stats[name].minExecTime, execTime);
+    Stats::stats[name].maxExecTime = std::max(Stats::stats[name].maxExecTime, execTime);
+}


### PR DESCRIPTION
J'ai repris les fonctions de stats d'appels de fonctions qu'on avais dans ft_vox

Headers:

```cpp
// -- getStats for clasic functions --------------------------------------------

// return non void
template<typename RetT, typename ...Args>
RetT getStats(std::string name, RetT (&func)(Args...), Args... args);

// return void
template<typename ...Args>
void getStatsVoid(std::string name, void (&func)(Args...), Args... args);


// -- getStats for member function ---------------------------------------------

// return non void
template<typename RetT, typename ClassT, typename ...Args>
RetT getStatsM(std::string name, ClassT &obj, RetT (ClassT::*func)(Args...), Args... args);

// return void
template<typename ClassT, typename ...Args>
void getStatsMVoid(std::string name, ClassT &obj, void (ClassT::*func)(Args...), Args... args);
```

Ça fonctionne que pour les fonctions publiques par contre

Exemple d'usage:

```diff
-  bool a = hey(42);
+  bool a = getStats<bool, int>("hey", &hey, 42);
```

```diff
-  heyRetVoid(42);
+  getStatsVoid<bool, int>("heyRetVoid", &heyRetVoid, 42);
```

```diff
-  this->calcGreedyChunk();
+  getStatsMVoid<GreedyChunk3>("calcGreedyChunk", *this, &GreedyChunk3::calcGreedyChunk);
```

```diff
- _sceneMap[_scene]->update()
+ getStatsM<bool, AScene>("update", *_sceneMap[_scene], AScene::update)
```

J'ai fait un test dans le programe sur SceneGame update/draw dans le dernier level, voilà le retour:
```
[DEBUG]: functions calls stats:
[DEBUG]: SceneGame update{
[DEBUG]:   function called: 3887 times
[DEBUG]:   total exec time: 3.85241299s
[DEBUG]:   average: 0.00099110s
[DEBUG]:   min: 0.00000441s
[DEBUG]:   min: 0.02475878s
[DEBUG]: }
[DEBUG]: SceneGame draw{
[DEBUG]:   function called: 3887 times
[DEBUG]:   total exec time: 119.71526061s
[DEBUG]:   average: 0.03079888s
[DEBUG]:   min: 0.01683456s
[DEBUG]:   min: 0.06699984s
[DEBUG]: }

```
(revenez un commit avant si vous voulez tester)