### PR TITLE
optimize bomberman-assets 3d models

### DIFF
--- a/srcs/scenes/SceneManager.cpp
+++ b/srcs/scenes/SceneManager.cpp
@@ -290,7 +290,13 @@ bool SceneManager::_update() {
 	/* scene */
 	if (!_isInCheatCode && !cheatCodeClosed) {
 		// update the scene
-		if (_sceneMap[_scene]->update() == false) {
+		if (_scene == SceneNames::GAME) {
+			if (getStatsM<bool, AScene>("SceneGame update", *_sceneMap[_scene], &AScene::update) == false) {
+				logErr("Unexpected error when updating scene");
+				return false;
+			}
+		}
+		else if (_sceneMap[_scene]->update() == false) {
 			logErr("Unexpected error when updating scene");
 			return false;
 		}
@@ -319,7 +325,13 @@ bool SceneManager::_draw() {
 	}
 
 	// draw the scene
-	if (_sceneMap[_scene]->draw() == false) {
+	if (_scene == SceneNames::GAME) {
+		if (getStatsM<bool, AScene>("SceneGame draw", *_sceneMap[_scene], &AScene::draw) == false) {
+			logErr("Unexpected error when drawing scene");
+			return false;
+		}
+	}
+	else if (_sceneMap[_scene]->draw() == false) {
 		logErr("Unexpected error when drawing scene");
 		return false;
 	}

--- a/srcs/utils/Stats.cpp
+++ b/srcs/utils/Stats.cpp
@@ -39,7 +39,7 @@ void    Stats::printStats() {
                 stat.second.minExecTime.count() << "s");
         }
         if (stat.second.maxExecTime != std::chrono::duration<double>::min()) {
-            logDebug("  min: " << std::fixed << std::setprecision(8) <<
+            logDebug("  max: " << std::fixed << std::setprecision(8) <<
                 stat.second.maxExecTime.count() << "s");
         }
         logDebug("}");


### PR DESCRIPTION
Pas de changement de code, j'ai juste optimisé les models pour gagner un peu en fps:
- decoupage du terrain pour que le frustum culling soit plus performant, avant le sol etait en un seul mesh donc il s'affichait en entier tout le temps, maintenant on affiche que le centre
- suppresions de quelques arbres et pierres du terrain
- flower: je suis passé de 10 584 à 5 042 faces, j'en ai profité pour lui faire une texture
- follow: de 8 800 à 3200,et update de la texture
- flyngBot: de 13 177 à 5 192