### PR TITLE
Add blur effect to the menu background for better readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Bomberman is a series of video games from Hudson Soft where the player plays a b
 
 > View the full game rules in the in-game **help menu**.
 
-![example game gif video here](/assets/GIFs/example.gif)
+![demo gif](../media/bombermanDemo.gif?raw=true)
 
 ### ⌨ General controls
 
 You can see and update all controls in the in-game **settings menu**.
 
-![Control menu image here](/assets/GIFs/example.png)
+![control menu](../media/ControlsMenu.png?raw=true)
 
 Some hidden debug controls:
 
@@ -33,11 +33,15 @@ Some hidden debug controls:
 
 ### 💾 save & load system
 
-![save_menu image here](/assets/GIFs/example.png)
+Save and load your progress:
+
+![save menu](../media/saveMenu.png?raw=true)
 
 ### 👩‍💻 Cheatcodes
 
 You can enter cheatcode by pressing the <kbd>/</kbd> key.
+
+![cheatcode menu](../media/cheatcode.png?raw=true)
 
 | Command  | Description |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ make help
 ### 📖 The code is fully documented with doxygen
 Check the documentation [here](https://tnicolas42.github.io/bomberman)
 
+### 🍩 3d models
+All 3d models are made by us with blender, some are animated using Mixamo, [Inspect 3d models here](https://sketchfab.com/zer0nim/collections/bomberman).
+
 ## 🦄 Authors
 
 * **Ernest Marin** - [github](https://github.com/zer0nim)

--- a/includes/scenes/ASceneMenu.hpp
+++ b/includes/scenes/ASceneMenu.hpp
@@ -21,6 +21,14 @@
 #define VOID_COLOR glm::vec4 {-1 , -1, -1, -1}
 
 /**
+ * @brief Struct TransparentBox, store transparent ui pos/size for blur effect
+ */
+struct	TransparentBox {
+	glm::vec2	pos;  /**< The box position */
+	glm::vec2	size;  /**< The box size */
+};
+
+/**
  * @brief Scene object to re-implement in all scenes for menu
  *
  * this object contains functions to create buttons, images, ...
@@ -68,6 +76,12 @@ class ASceneMenu : public AScene {
 	protected:
 		std::vector<ABaseUI *>	_buttons;  /**< All UI elements (auto added with addXXX functions) */
 		bool					_draw3dMenu;  /**< True if the menu background is in 3D */
+		/* blur effect */
+		bool	_blurEnabled;  /**< If enabled blur transparent ui */
+		static	std::vector<uint8_t>		_aMaskData;  /**< Blur mask texture raw data */
+		static	std::vector<TransparentBox>	_transparentBoxs;  /**< Transparents box to be blured */
 
-		bool			_initBG();
+		bool	_initBG();
+		bool	_updateAlphaMask();
+		bool	_updateAlphaMaskData();
 };

--- a/includes/scenes/SceneGame.hpp
+++ b/includes/scenes/SceneGame.hpp
@@ -20,6 +20,10 @@
 
 #define NO_LEVEL -1  // value is no level loaded
 #define LEVEL_INTRO_DURATION 2
+#define BLUR_SHADER_VS "shaders/blur_vs.glsl"
+#define BLUR_SHADER_FS "shaders/blur_fs.glsl"
+#define PP_VAO_WIDTH 4
+#define PP_V_ARRAY_SIZE 24
 
 class Player;
 class AEnemy;
@@ -83,13 +87,22 @@ private:
 		DrawForMenu();
 	};
 	DrawForMenu _menuModels;  /**< All 3D elements to draw */
-	bool	_alarm;  /**< If we want to ring alarm */
-	Model	*_terrain;  /**< The terrain element */
+	bool		_alarm;  /**< If we want to ring alarm */
+	Model		*_terrain;  /**< The terrain element */
+	// post processing stuff
+	Shader		*_blurShader;  /**< PostProcess blur shader */
+	static std::array<float, PP_V_ARRAY_SIZE> const	_ppVertices;  /**< Vertices data */
+	uint32_t	_ppShVbo;  /**< PostProcess vbo */
+	uint32_t	_ppShVao;  /**< PostProcess vao */
+	uint32_t	_blurFbo[2];  /**< PostProcess blur framebuffer */
+	uint32_t	_blurTexColor[2];  /**< PostProcess blur texture */
+	uint32_t	_rbo;  /**< renderBufferObject to store depth and stencil buffers */
 
 	// Methods
 	bool	_loadLevel(int32_t levelId);
 	bool	_unloadLevel();
 	bool	_initJsonLevel(int32_t levelId);
+	bool	_initPostProcess();
 	void	_drawBoard();
 
 protected:

--- a/includes/scenes/SceneGame.hpp
+++ b/includes/scenes/SceneGame.hpp
@@ -97,6 +97,7 @@ private:
 	uint32_t	_blurFbo[2];  /**< PostProcess blur framebuffer */
 	uint32_t	_blurTexColor[2];  /**< PostProcess blur texture */
 	uint32_t	_rbo;  /**< renderBufferObject to store depth and stencil buffers */
+	uint32_t	_blurMaskTex;  /**< The blur mask texture */
 
 	// Methods
 	bool	_loadLevel(int32_t levelId);
@@ -210,6 +211,7 @@ public:
 	std::string		print() const;
 	bool			clearFromBoard(AEntity *entity, glm::vec2 pos);
 	bool			positionInGame(glm::vec3 pos, glm::vec3 sz = glm::vec3(1, 1, 1));
+	bool			updateBlurMaskTex(std::vector<uint8_t> const &aMaskData);
 
 	// SceneGame methods
 	virtual bool	init();

--- a/includes/scenes/SceneGame.hpp
+++ b/includes/scenes/SceneGame.hpp
@@ -212,6 +212,8 @@ public:
 	bool			clearFromBoard(AEntity *entity, glm::vec2 pos);
 	bool			positionInGame(glm::vec3 pos, glm::vec3 sz = glm::vec3(1, 1, 1));
 	bool			updateBlurMaskTex(std::vector<uint8_t> const &aMaskData);
+	void			blurFilterBefore();
+	void			blurFilterAfter();
 
 	// SceneGame methods
 	virtual bool	init();

--- a/includes/utils/opengl/UI/ABaseUI.hpp
+++ b/includes/utils/opengl/UI/ABaseUI.hpp
@@ -150,6 +150,8 @@ class ABaseUI {
 		virtual bool				isEnabled() const;
 		virtual glm::vec2 &			getPos();
 		virtual glm::vec2 const &	getPos() const;
+		virtual float				getZ() const;
+		virtual glm::vec4			getColor() const;
 		virtual glm::vec2			getRealPos() const;  // get master + pos + offset
 		virtual glm::vec2 &			getSize();
 		virtual glm::vec2 const &	getSize() const;

--- a/scripts/Doxyfile
+++ b/scripts/Doxyfile
@@ -44,7 +44,7 @@ PROJECT_NUMBER         =
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          =
+PROJECT_BRIEF          = "3d remake of the classic game Bomberman in C++ with OpenGL."
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55

--- a/shaders/blur_fs.glsl
+++ b/shaders/blur_fs.glsl
@@ -1,0 +1,37 @@
+#version 410 core
+
+out vec4 FragColor;
+
+in vec2 TexCoords;
+
+uniform sampler2D sceneTex;
+uniform bool horizontal = true;
+// gausian blur weight
+uniform float weight[5] = float[] (0.227027, 0.1945946, 0.1216216, 0.054054, 0.016216);
+
+void	main() {
+	if (gl_FragCoord.y > 400) {
+		FragColor = texture(sceneTex, TexCoords);
+	}
+	else {
+		// gets size of single texel
+		vec2 texOffset = 1.0 / textureSize(sceneTex, 0);
+		// current fragment's contribution
+		vec3 result = texture(sceneTex, TexCoords).rgb * weight[0];
+
+		if (horizontal) {
+			for (int i = 1; i < 5; ++i) {
+				result += texture(sceneTex, TexCoords + vec2(texOffset.x * i, 0.0)).rgb * weight[i];
+				result += texture(sceneTex, TexCoords - vec2(texOffset.x * i, 0.0)).rgb * weight[i];
+			}
+		}
+		else {
+			for (int i = 1; i < 5; ++i) {
+				result += texture(sceneTex, TexCoords + vec2(0.0, texOffset.y * i)).rgb * weight[i];
+				result += texture(sceneTex, TexCoords - vec2(0.0, texOffset.y * i)).rgb * weight[i];
+			}
+		}
+
+		FragColor = vec4(result, 1.0);
+	}
+}

--- a/shaders/blur_fs.glsl
+++ b/shaders/blur_fs.glsl
@@ -5,14 +5,18 @@ out vec4 FragColor;
 in vec2 TexCoords;
 
 uniform sampler2D sceneTex;
+uniform sampler2D blurMaskTex;
 uniform bool horizontal = true;
 // gausian blur weight
 uniform float weight[5] = float[] (0.227027, 0.1945946, 0.1216216, 0.054054, 0.016216);
 
 void	main() {
-	if (gl_FragCoord.y > 400) {
+	float blurMask = texture(blurMaskTex, TexCoords).r;
+	// don't blur part not covered by the mask
+	if (blurMask == 0.0) {
 		FragColor = texture(sceneTex, TexCoords);
 	}
+	// else apply the blur
 	else {
 		// gets size of single texel
 		vec2 texOffset = 1.0 / textureSize(sceneTex, 0);

--- a/shaders/blur_vs.glsl
+++ b/shaders/blur_vs.glsl
@@ -1,0 +1,11 @@
+#version 410 core
+
+layout (location = 0) in vec2 aPos;
+layout (location = 1) in vec2 aTexCoords;
+
+out vec2 TexCoords;
+
+void	main()	{
+	gl_Position = vec4(aPos.x, aPos.y, 0.0, 1.0);
+	TexCoords = aTexCoords;
+}

--- a/shaders/cube_fs.glsl
+++ b/shaders/cube_fs.glsl
@@ -64,7 +64,7 @@ uniform float nightProgress = 0.0;
 vec3 calcDirLight(DirLight light, vec3 norm, vec3 viewDir, vec3 color) {
 	vec3	lightDir = normalize(-light.direction);
 	// diffuse
-	float	diff = max(dot(norm, lightDir), 0.0);
+	float	diff = max(dot(lightDir, norm), 0.0);  // result between 0 and 1
 	// specular
 	vec3 halfwayDir = normalize(lightDir + viewDir);
 	float spec = pow(max(dot(norm, halfwayDir), 0.0), material.shininess * 4);

--- a/shaders/model_fs.glsl
+++ b/shaders/model_fs.glsl
@@ -39,7 +39,7 @@ uniform DirLight	dirLight;
 vec3 calcDirLight(DirLight light, vec3 norm, vec3 viewDir) {
 	vec3	lightDir = normalize(-fs_in.TangentLightDir);
 	// diffuse
-	float	diff = max(dot(lightDir, norm), 0.0);
+	float	diff = max(dot(lightDir, norm), 0.0);  // result between 0 and 1
 	// specular
 	vec3	halfwayDir = normalize(lightDir + viewDir);
 	float	spec = pow(max(dot(norm, halfwayDir), 0.0), material.shininess * 4);

--- a/srcs/scenes/SceneCheatCode.cpp
+++ b/srcs/scenes/SceneCheatCode.cpp
@@ -19,6 +19,7 @@ SceneCheatCode::SceneCheatCode(Gui * gui, float const &dtTime)
   _historyActID(-1)
 {
 	_draw3dMenu = false;
+	_blurEnabled = false;
 	_commandsList = {
 		{"help", {
 			"[command, ...]",

--- a/srcs/scenes/SceneDebug.cpp
+++ b/srcs/scenes/SceneDebug.cpp
@@ -13,6 +13,7 @@ SceneDebug::SceneDebug(Gui * gui, float const &dtTime)
 : ASceneMenu(gui, dtTime)
 {
 	_draw3dMenu = false;
+	_blurEnabled = false;
 	_lastUpdateMs = getMs();
 	_fps = SceneManager::getFps();
 }

--- a/srcs/scenes/SceneGame/SceneGame.cpp
+++ b/srcs/scenes/SceneGame/SceneGame.cpp
@@ -85,6 +85,7 @@ SceneGame::SceneGame(Gui * gui, float const &dtTime)
 	_terrain = nullptr;
 	_blurShader = 0;
 	_rbo = 0;
+	_blurMaskTex = 0;
 	enemiesToKill = 0;
 	enemiesKilled = 0;
 	_alarm = false;
@@ -121,6 +122,7 @@ SceneGame::~SceneGame() {
 
 	glDeleteFramebuffers(2, _blurFbo);
 	glDeleteTextures(2, _blurTexColor);
+	glDeleteTextures(1, &_blurMaskTex);
 }
 
 /**

--- a/srcs/scenes/SceneGame/SceneGame.cpp
+++ b/srcs/scenes/SceneGame/SceneGame.cpp
@@ -118,6 +118,9 @@ SceneGame::~SceneGame() {
 	delete _menuModels.crispy;
 	delete _menuModels.follow;
 	delete _terrain;
+
+	glDeleteFramebuffers(2, _blurFbo);
+	glDeleteTextures(2, _blurTexColor);
 }
 
 /**

--- a/srcs/scenes/SceneGame/SceneGame.cpp
+++ b/srcs/scenes/SceneGame/SceneGame.cpp
@@ -46,6 +46,18 @@ std::map<std::string, SceneGame::Entity> SceneGame::entitiesCall = {
 	{ENEMY_FROG_STR, {EntityType::ENEMY, [](SceneGame &game) -> AEntity* {return new EnemyFrog(game);}}},
 };
 
+// postProcess face vertices
+std::array<float, PP_V_ARRAY_SIZE> const	SceneGame::_ppVertices = {{
+	// x, y in normalized device coord, texCoord.u, texCoord.v
+	-1.0f, 1.0f,  0.0f, 1.0f,
+	-1.0f, -1.0f,  0.0f, 0.0f,
+	1.0f, -1.0f,  1.0f, 0.0f,
+
+	-1.0f, 1.0f,  0.0f, 1.0f,
+	1.0f, -1.0f,  1.0f, 0.0f,
+	1.0f, 1.0f,  1.0f, 1.0f
+}};
+
 // -- Constructors -------------------------------------------------------------
 
 /**
@@ -54,7 +66,10 @@ std::map<std::string, SceneGame::Entity> SceneGame::entitiesCall = {
  * @param gui A pointer on the gui object
  * @param dtTime A reference to the delta time
  */
-SceneGame::SceneGame(Gui * gui, float const &dtTime) : ASceneMenu(gui, dtTime) {
+SceneGame::SceneGame(Gui * gui, float const &dtTime)
+: ASceneMenu(gui, dtTime),
+  _blurFbo{0, 0},
+  _blurTexColor{0, 0} {
 	player = nullptr;
 	enemies = std::vector<AEnemy *>();
 	flags = 0;
@@ -68,6 +83,8 @@ SceneGame::SceneGame(Gui * gui, float const &dtTime) : ASceneMenu(gui, dtTime) {
 	levelCrispies = 0;
 	_draw3dMenu = false;  // disable drawing 3D menu
 	_terrain = nullptr;
+	_blurShader = 0;
+	_rbo = 0;
 	enemiesToKill = 0;
 	enemiesKilled = 0;
 	_alarm = false;

--- a/srcs/scenes/SceneGame/SceneGame_draw.cpp
+++ b/srcs/scenes/SceneGame/SceneGame_draw.cpp
@@ -79,7 +79,9 @@ bool	SceneGame::drawForMenu() {
  * @return false If failed
  */
 bool	SceneGame::drawGame() {
-	blurFilterBefore();  // blur filter settings, enable framebuffer
+	if (state != GameState::INTRO) {
+		blurFilterBefore();  // blur filter settings, enable framebuffer
+	}
 
 	// draw background terrain
 	if (s.j("debug").j("show").b("terrain")) {
@@ -181,7 +183,9 @@ bool	SceneGame::drawGame() {
 		allUI.introText->draw();
 	}
 
-	blurFilterAfter();  // blur filter postprocess
+	if (state != GameState::INTRO) {
+		blurFilterAfter();  // blur filter postprocess
+	}
 
 	return true;
 }
@@ -192,6 +196,8 @@ bool	SceneGame::drawGame() {
  * @return false If failed
  */
 bool	SceneGame::drawVictory() {
+	blurFilterBefore();  // blur filter settings, enable framebuffer
+
 	/* draw models */
 	try {
 		_menuModels.player->transform.setRot(0);
@@ -215,6 +221,8 @@ bool	SceneGame::drawVictory() {
 	glm::mat4	view = _gui->cam->getViewMatrix();
 	_gui->drawSkybox(view);
 
+	blurFilterAfter();  // blur filter postprocess
+
 	return true;
 }
 
@@ -224,6 +232,8 @@ bool	SceneGame::drawVictory() {
  * @return false If failed
  */
 bool	SceneGame::drawGameOver() {
+	blurFilterBefore();  // blur filter settings, enable framebuffer
+
 	/* draw models */
 	try {
 		_menuModels.player->transform.setRot(0);
@@ -246,6 +256,8 @@ bool	SceneGame::drawGameOver() {
 	// draw skybox
 	glm::mat4	view = _gui->cam->getViewMatrix();
 	_gui->drawSkybox(view);
+
+	blurFilterAfter();  // blur filter postprocess
 
 	return true;
 }

--- a/srcs/scenes/SceneGame/SceneGame_draw.cpp
+++ b/srcs/scenes/SceneGame/SceneGame_draw.cpp
@@ -91,8 +91,15 @@ bool	SceneGame::drawForMenu() {
 		_blurShader->use();
 		_blurShader->setBool("horizontal", horizontal);
 		glBindVertexArray(_ppShVao);
+		// fbo texture
+		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, _blurTexColor[i % 2]);
+		// mask texture
+		glActiveTexture(GL_TEXTURE1);
+		glBindTexture(GL_TEXTURE_2D, _blurMaskTex);
+		// draw the quad
 		glDrawArrays(GL_TRIANGLES, 0, 6);
+		glActiveTexture(GL_TEXTURE0);
 		_blurShader->unuse();
 
 		horizontal = !horizontal;

--- a/srcs/scenes/SceneGame/SceneGame_update.cpp
+++ b/srcs/scenes/SceneGame/SceneGame_update.cpp
@@ -311,7 +311,7 @@ bool	SceneGame::postUpdate() {
 /**
  * @brief Update game informations
  */
-void			SceneGame::_updateGameInfos() {
+void	SceneGame::_updateGameInfos() {
 	glm::vec2	winSz = _gui->gameInfo.windowSize;
 	glm::vec2	tmpPos;
 	float		imgY;
@@ -543,4 +543,47 @@ void			SceneGame::_updateGameInfos() {
 	} catch (ABaseUI::UIException const & e) {
 		logErr(e.what());
 	}
+}
+
+/**
+ * @brief Update the blur Mask texture
+ *
+ * @param aMaskData mask texture raw data
+ * @return true on success
+ * @return false on failure
+ */
+bool	SceneGame::updateBlurMaskTex(std::vector<uint8_t> const &aMaskData) {
+	glm::vec2 winSize = _gui->gameInfo.windowSize;
+
+	// create the texture the first time
+	if (_blurMaskTex == 0) {
+		glGenTextures(1, &_blurMaskTex);
+		glActiveTexture(GL_TEXTURE1);
+		glBindTexture(GL_TEXTURE_2D, _blurMaskTex);
+		// create the texture
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_R8, winSize.x, winSize.y, 0, GL_RED,
+			GL_UNSIGNED_BYTE, &aMaskData[0]);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+		glBindTexture(GL_TEXTURE_2D, 0);
+		// tell
+		_blurShader->use();
+		_blurShader->setInt("sceneTex", 0);
+		_blurShader->setInt("blurMaskTex", 1);
+		_blurShader->unuse();
+	}
+	// else just update the data
+	else {
+		glActiveTexture(GL_TEXTURE1);
+		glBindTexture(GL_TEXTURE_2D, _blurMaskTex);
+		// update texture data
+		glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, winSize.x, winSize.y, GL_RED,
+			GL_UNSIGNED_BYTE, &aMaskData[0]);
+		glBindTexture( GL_TEXTURE_2D, 0);
+	}
+	glActiveTexture(GL_TEXTURE0);
+
+	return true;
 }

--- a/srcs/scenes/SceneLoading.cpp
+++ b/srcs/scenes/SceneLoading.cpp
@@ -14,6 +14,7 @@ SceneLoading::SceneLoading(Gui * gui, float const &dtTime)
 : ASceneMenu(gui, dtTime)
 {
 	_draw3dMenu = false;
+	_blurEnabled = false;
 }
 
 /**

--- a/srcs/scenes/SceneManager.cpp
+++ b/srcs/scenes/SceneManager.cpp
@@ -319,11 +319,6 @@ bool SceneManager::_draw() {
 	/* draw */
 	_gui->preDraw();
 
-	// draw debug menu scene
-	if (_sceneMap[SceneNames::DEBUG_MENU]->draw() == false) {
-		return false;
-	}
-
 	// draw the scene
 	if (_scene == SceneNames::GAME) {
 		if (getStatsM<bool, AScene>("SceneGame draw", *_sceneMap[_scene], &AScene::draw) == false) {
@@ -342,6 +337,11 @@ bool SceneManager::_draw() {
 			logErr("Unexpected error when drawing scene");
 			return false;
 		}
+	}
+
+	// draw debug menu scene
+	if (_sceneMap[SceneNames::DEBUG_MENU]->draw() == false) {
+		return false;
 	}
 
 	_gui->postDraw();

--- a/srcs/scenes/SceneManager.cpp
+++ b/srcs/scenes/SceneManager.cpp
@@ -290,13 +290,7 @@ bool SceneManager::_update() {
 	/* scene */
 	if (!_isInCheatCode && !cheatCodeClosed) {
 		// update the scene
-		if (_scene == SceneNames::GAME) {
-			if (_sceneMap[_scene]->update() == false) {
-				logErr("Unexpected error when updating scene");
-				return false;
-			}
-		}
-		else if (_sceneMap[_scene]->update() == false) {
+		if (_sceneMap[_scene]->update() == false) {
 			logErr("Unexpected error when updating scene");
 			return false;
 		}
@@ -320,13 +314,7 @@ bool SceneManager::_draw() {
 	_gui->preDraw();
 
 	// draw the scene
-	if (_scene == SceneNames::GAME) {
-		if (_sceneMap[_scene]->draw() == false) {
-			logErr("Unexpected error when drawing scene");
-			return false;
-		}
-	}
-	else if (_sceneMap[_scene]->draw() == false) {
+	if (_sceneMap[_scene]->draw() == false) {
 		logErr("Unexpected error when drawing scene");
 		return false;
 	}

--- a/srcs/utils/opengl/UI/ABaseUI.cpp
+++ b/srcs/utils/opengl/UI/ABaseUI.cpp
@@ -609,6 +609,18 @@ glm::vec2 &			ABaseUI::getPos() { return _pos; }
  */
 glm::vec2 const &	ABaseUI::getPos() const { return _pos; }
 /**
+ * @brief Get the z position
+ *
+ * @return float the z position
+ */
+float				ABaseUI::getZ() const { return _z; }
+/**
+ * @brief Get the ui color
+ *
+ * @return glm::vec4 the ui color in rgba order
+ */
+glm::vec4			ABaseUI::getColor() const { return _color; }
+/**
  * @brief Get the real position (position + master position + offset)
  *
  * @return glm::vec2 The real position


### PR DESCRIPTION
Ça y est l'effet de blur est normalement fonctionnel.

En gros ça fonctionne comme ça:
- Je crée une texture de masque, en blanc là ou il y a du blur a afficher et noir le reste, elle est uniquement maj quand necessaire.
- je change le framebuffer avant de dessiner le jeu ou le background du menu principal, ça permet de dessiner la scene non pas a l'ecran mais dans une texture
- j'applique l'effet de blur a l'aide de la texture precedement créé et du masque

et voilà 😅

Si ça vous interesse d'en savoir plus:
https://learnopengl.com/Advanced-OpenGL/Framebuffers
https://www.youtube.com/watch?v=uZlwbWqQKpc
https://learnopengl.com/Advanced-Lighting/Bloom

Close #244 